### PR TITLE
Moved dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,13 +19,13 @@
   ],
   "dependencies": {
     "paper-elements": "Polymer/paper-elements#master",
-    "core-elements": "Polymer/core-elements#master"
+    "core-elements": "Polymer/core-elements#master",
+    "fin-canvas": "#master",
+    "fin-rectangle": "#master",
+    "fin-vampire-bar": "#master"
   },
   "devDependencies": {
     "polymer": "Polymer/polymer#master",
-    "fin-canvas": "#master",
-    "fin-rectangle": "#master",
-    "fin-vampire-bar": "#master",
     "accountingjs": "~0.3.2"
   }
 }


### PR DESCRIPTION
Unfortunatly having `fin-*` in `devDependencies` creates a lot of 404 errors:

![screenshot 2015-02-10 14 47 52](https://cloud.githubusercontent.com/assets/99223/6129132/dda77788-b133-11e4-9c29-f4651c8402c2.png)
