### PR TITLE
CellEditors API is now an object that remembers grid ref

### DIFF
--- a/demo/js/widedata.js
+++ b/demo/js/widedata.js
@@ -25,6 +25,7 @@
         var birthyear = 1900 + Math.round(randomFunc() * 114);
         var birthmonth = Math.round(randomFunc() * 11);
         var birthday = Math.round(randomFunc() * 29);
+        var birthTime = Math.round(randomFunc() * 60 * 24);
         var birthstate = Math.round(randomFunc() * (states.length - 1));
         var residencestate = Math.round(randomFunc() * (states.length - 1));
         var travel = randomFunc() * 1000;
@@ -50,6 +51,7 @@
             total_number_of_pets_owned: pets,
             height: height,
             birthDate: new Date(birthyear + '-' + months[birthmonth] + '-' + days[birthday]),
+            birthTime: birthTime,
             birthState: states[birthstate],
             residenceState: states[residencestate],
             employed: employed === 1,
@@ -63,6 +65,7 @@
             one_height: height,
             one_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             one_birthState: states[birthstate],
+            one_birthTime: birthTime,
             one_residenceState: states[residencestate],
             one_employed: employed === 1,
             one_income: income,
@@ -75,6 +78,7 @@
             two_height: height,
             two_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             two_birthState: states[birthstate],
+            two_birthTime: birthTime,
             two_residenceState: states[residencestate],
             two_employed: employed === 1,
             two_income: income,
@@ -87,6 +91,7 @@
             three_height: height,
             three_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             three_birthState: states[birthstate],
+            three_birthTime: birthTime,
             three_residenceState: states[residencestate],
             three_employed: employed === 1,
             three_income: income,
@@ -99,6 +104,7 @@
             four_height: height,
             four_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             four_birthState: states[birthstate],
+            four_birthTime: birthTime,
             four_residenceState: states[residencestate],
             four_employed: employed === 1,
             four_income: income,
@@ -111,6 +117,7 @@
             five_height: height,
             five_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             five_birthState: states[birthstate],
+            five_birthTime: birthTime,
             five_residenceState: states[residencestate],
             five_employed: employed === 1,
             five_income: income,
@@ -123,6 +130,7 @@
             six_height: height,
             six_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             six_birthState: states[birthstate],
+            six_birthTime: birthTime,
             six_residenceState: states[residencestate],
             six_employed: employed === 1,
             six_income: income,
@@ -135,6 +143,7 @@
             seven_height: height,
             seven_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             seven_birthState: states[birthstate],
+            seven_birthTime: birthTime,
             seven_residenceState: states[residencestate],
             seven_employed: employed === 1,
             seven_income: income,
@@ -147,6 +156,7 @@
             eight_height: height,
             eight_birthDate: birthyear + '-' + months[birthmonth] + '-' + days[birthday],
             eight_birthState: states[birthstate],
+            eight_birthTime: birthTime,
             eight_residenceState: states[residencestate],
             eight_employed: employed === 1,
             eight_income: income,

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -21,7 +21,7 @@ var stylesheet = require('./lib/stylesheet');
 var Localization = require('./lib/Localization');
 var behaviors = require('./behaviors');
 var cellRenderers = require('./cellRenderers');
-var cellEditors = require('./cellEditors');
+var CellEditors = require('./cellEditors');
 
 var themeInitialized = false,
     polymerTheme = Object.create(defaults),
@@ -100,6 +100,8 @@ function Hypergrid(div, options) {
     margin.right = margin.right || '-200px';
     margin.bottom = margin.bottom || 0;
     margin.left = margin.left || 0;
+
+    this.cellEditors = new CellEditors(this);
 
     this.allowEventHandlers = true;
 
@@ -295,14 +297,6 @@ Hypergrid.prototype = {
         return p && p.x === x && p.y === y;
     },
 
-    /** @summary Register localizer and create and register a cell editor class that uses it.
-     * @param {string} name - The new localizer's name, converted to all lower case.
-     * @param {localizerInterface} localizer
-     */
-    registerLocalizer: function(name, localizer) {
-        this.localization.add(name, localizer);
-    },
-
     getFormatter: function(localizerName) {
         return this.localization.get(localizerName).format;
     },
@@ -316,17 +310,6 @@ Hypergrid.prototype = {
      * All references to this shared API should go through your grid instance in case we decide to make it an object later and instance it for each grid.
      */
     cellRenderers: cellRenderers,
-
-    /**
-     * All references to this shared API should go through your grid instance in case we decide to make it an object later and instance it for each grid.
-     */
-    cellEditors: cellEditors,
-
-
-    /**
-     * This mix-in is purely for calling convenience, automatically setting the context to grid as required by cellEditors.create.
-     */
-    createCellEditor: cellEditors.create,
 
     /**
      * @memberOf Hypergrid.prototype

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -101,6 +101,10 @@ function Hypergrid(div, options) {
     margin.bottom = margin.bottom || 0;
     margin.left = margin.left || 0;
 
+    /**
+     * @type {CellEditors}
+     * @memberOf Hypergrid.prototype
+     */
     this.cellEditors = new CellEditors(this);
 
     this.allowEventHandlers = true;
@@ -308,6 +312,8 @@ Hypergrid.prototype = {
 
     /**
      * All references to this shared API should go through your grid instance in case we decide to make it an object later and instance it for each grid.
+     * @type {object}
+     * @memberOf Hypergrid.prototype
      */
     cellRenderers: cellRenderers,
 

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -1378,7 +1378,7 @@ var Behavior = Base.extend('Behavior', {
      */
     getCellEditorAt: function(x, y) {
         return this.grid.isFilterRow(y)
-            ? this.grid.createCellEditor('filterbox')
+            ? this.grid.cellEditors.create('filterbox')
             : this.getActiveColumn(x).getCellEditorAt(y);
     },
 

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -35,7 +35,7 @@ var CellEditor = Base.extend('CellEditor', {
          */
         this.grid = grid;
 
-        this.locale = grid.localization.locale;
+        this.locale = grid.localization.locale; // for template's `lang` attribute
 
         this.editorPoint = {
             x: 0,
@@ -349,11 +349,16 @@ var CellEditor = Base.extend('CellEditor', {
                 '   * Cancel editing by pressing the "esc" (escape) key.';
 
             error = error.message || error;
+
             if (typeof error !== 'string') {
-                error = this.localizer.expectation;
+                error = '';
             }
 
-            if (typeof error === 'string') {
+            if (this.localizer.expectation) {
+                error = error ? error + '\n' + this.localizer.expectation : this.localizer.expectation;
+            }
+
+            if (error) {
                 error = '\n' + error;
                 error = error.replace(/[\n\r]+/g, '\n\n   * ');
                 msg += '\n\nAdditional information about this error:' + error;
@@ -376,6 +381,7 @@ var CellEditor = Base.extend('CellEditor', {
      * @memberOf CellEditor.prototype
      */
     errorEffect: 'shaker',
+
     /**
      * Hash of registered {@link effectFunction}s or {@link effectObject}s.
      * @memberOf CellEditor.prototype

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -19,7 +19,6 @@ var CellEditor = Base.extend('CellEditor', {
      * @param {string} [options] - Properties to copy to the new cell editor primarily for mustache's use.
      */
     initialize: function(grid, options) {
-
         if (options) {
             for (var key in options) {
                 if (options.hasOwnProperty(key) && this[key] !== null) {
@@ -198,8 +197,13 @@ var CellEditor = Base.extend('CellEditor', {
     },
 
     /**
-     * @desc put value into our editor
-     * @param {object} value - whatever value we want to edit
+     * @summary Put the value into our editor.
+     * @desc Formats the value and displays it.
+     * The localizer's {@link localizerInterface#format|format} method will be called.
+     *
+     * Override this method if your editor has additional or alternative GUI elements.
+     *
+     * @param {object} value - The raw unformatted value from the data source that we want to edit.
      * @memberOf CellEditor.prototype
      */
     setEditorValue: function(value) {
@@ -408,7 +412,12 @@ var CellEditor = Base.extend('CellEditor', {
     },
 
     /**
-     * @desc return the current editor's value
+     * @summary Extract the edited value from the editor.
+     * @desc De-format the edited string back into a primitive value.
+     *
+     * The localizer's {@link localizerInterface#parse|parse} method will be called on the text box contents.
+     *
+     * Override this method if your editor has additional or alternative GUI elements. The GUI elements will influence the primitive value, either by altering the edited string before it is parsed, or by transforming the parsed value before returning it.
      * @returns {object} the current editor's value
      * @memberOf CellEditor.prototype
      */

--- a/src/cellRenderers/CellRenderer.js
+++ b/src/cellRenderers/CellRenderer.js
@@ -61,4 +61,6 @@ var CellRenderer = Base.extend('CellRenderer', {
     }
 });
 
+CellRenderer.abstract = true; // don't instantiate directly
+
 module.exports = CellRenderer;

--- a/src/cellRenderers/index.js
+++ b/src/cellRenderers/index.js
@@ -29,26 +29,31 @@ var cellRenderers = {
  *
  * > All native cell renderers are "preregistered" in cellRenderers/index.js.
  *
- * @param {YourCellRenderer.prototype.constructor} Constructor - A constructor, typically extended from `CellRenderer` (or a descendant therefrom).
+ * @param {string} [name] - Case-insensitive renderer key. If not given, `YourCellRenderer.prototype.$$CLASS_NAME` is used.
  *
- * @param {string} [rendererName] - Case-insensitive renderer key. If not given, `YourCellRenderer.prototype.$$CLASS_NAME` is used.
+ * @param {CellRenderer} Constructor - A constructor, typically extended from `CellRenderer` (or a descendant therefrom).
  *
  * > Note: `$$CLASS_NAME` can be easily set up by providing a string as the (optional) first parameter (`alias`) in your {@link https://www.npmjs.com/package/extend-me|CellEditor.extend} call.
  *
  * @memberOf module:cellRenderers
  */
-function add(Constructor, rendererName) {
-    rendererName = rendererName || Constructor.prototype.$$CLASS_NAME;
-    rendererName = rendererName && rendererName.toLowerCase();
-    return (cellRenderers[rendererName] = create(Constructor));
+function add(name, Constructor) {
+    if (typeof name === 'function') {
+        Constructor = name;
+        name = undefined;
+    }
+
+    name = name || Constructor.prototype.$$CLASS_NAME;
+    name = name && name.toLowerCase();
+    return (cellRenderers[name] = new Constructor);
 }
 
 /**
- * @param {string} rendererName
+ * @param {string} name
  * @returns {*}
  */
-function get(rendererName) {
-    return cellRenderers[rendererName && rendererName.toLowerCase()];
+function get(name) {
+    return cellRenderers[name && name.toLowerCase()];
 }
 
 // /**
@@ -67,27 +72,8 @@ function get(rendererName) {
 // function getRowHeaderCell(config) {
 // }
 
- /**
-  * Must be called with YOUR Hypergrid object as context!
-  * @returns {CellRenderer} New instance of the named cell renderer.
-  * @param {string} rendererName
-  * @private
-  */
-function create(CellRendererConstructor) {
-    var cellRenderer;
 
-    if (CellRendererConstructor) {
-        if (CellRendererConstructor.abstract) {
-            throw 'Attempt to instantiate an "abstract" cell renderer.';
-        }
-        cellRenderer = new CellRendererConstructor;
-    }
-
-    return cellRenderer;
-}
-
-
-add(require('./CellRenderer'), 'EmptyCell');
+add('EmptyCell', require('./CellRenderer'));
 add(require('./Button'));
 add(require('./SimpleCell'));
 add(require('./SliderCell'));

--- a/src/dataModels/DataModel.js
+++ b/src/dataModels/DataModel.js
@@ -84,7 +84,7 @@ var DataModel = Base.extend('DataModel', {
      * @memberOf DataModel.prototype
      */
     getCellEditorAt: function(x, y, declaredEditorName, options) {
-        return this.grid.createCellEditor(declaredEditorName, options);
+        return this.grid.cellEditors.create(declaredEditorName, options);
     }
 
 });

--- a/src/jsdoc/interfaces.js
+++ b/src/jsdoc/interfaces.js
@@ -6,10 +6,18 @@
  */
 
 /**
+ * @name localizerInterface#name
+ * @summary Name to use for registering the localizer.
+ * @desc Implementation of this property is optional.
+ * If undefined, a name will need to be supplied at registration time.
+ * @type {string}
+ */
+
+/**
+ * @name localizerInterface#format
  * @summary Transform a primitive value into a human-friendly string representation.
  * @desc Implementation of this method is required.
  * @method
- * @name localizerInterface#format
  * @param {*} value
  * @returns {string}
  */
@@ -25,19 +33,19 @@
  */
 
 /**
+ * @name localizerInterface#invalid
  * @summary Tests string representation for invalidity.
- *
  * @desc Implementation of this method is optional.
  *
  * The method may be strict or loose but caller has no way of knowing and must assume loose. Loose means it may return a false negative. This means that while a truthy return means invalid, falsy merely means "not invalid." In other words, you cannot assume that a falsy value means valid. The parser is the final arbiter and should be designed to throw an error on parser jam. For example, a number parser should not simply return NaN but should throw an error.
  *
  * Overridden by `options.invalid` passed to constructor.
  * @method
- * @name localizerInterface#invalid
  * @returns {boolean|string} Truthy value means invalid. If a string, this will be an error message. If not a string, it merely indicates a generic invalid result.
  */
 
 /**
+ * @name localizerInterface#expectation
  * @summary A string to use when no validation error message is available.
  * @desc Implementation of this property is optional.
  *
@@ -48,11 +56,10 @@
  * Overridden by `options.expectation` passed to constructor.
  *
  * @type {string}
- * @name localizerInterface#expectation
  */
 
 /**
- * Locale provided to constructor. Required.
- * @type {string}
  * @name localizerInterface#locale
+ * @summary Locale provided to constructor. Required.
+ * @type {string}
  */

--- a/src/jsdoc/tutorials/cell-editors.md
+++ b/src/jsdoc/tutorials/cell-editors.md
@@ -146,7 +146,7 @@ var Time = Textfield.extend('Time', { // optional class name aids debugging
 });
 ```
 
-(See {@link http://github.com/joneit/extend-me} for details on the `extend` method.)
+_NOTE: See {@link http://github.com/joneit/extend-me} for details on the `extend` method. The important point to understand here is that `initialize` is called on construction on every ancestor prototype first, from oldest to newest, before it is called on ours._
 
 #### Registration
 
@@ -164,7 +164,7 @@ Formatters are contained within localizers which are objects that are languistic
  * De-format (parse) edited values back into primitive types.
  * Optional: Validate edits that they conform to the format.
 
-Localizers are APIs (not instantiated objects) with both `format` and `parse` methods. Cell editors use both these methods. (Cell renderers also usew localizers but only use the `format` method.)
+Localizers are APIs (not instantiated objects) with both `format` and `parse` methods. Cell editors use both these methods. (Cell renderers also use localizers, but only the `format` method.)
 
 To load and edit the data in the _hh:mm_ format, we will use the `hhmm` localizer. (See the example in the full _{@tutorial localization}_ tutorial.) First make sure to register it (so it can be referenced by name):
 
@@ -451,17 +451,13 @@ This would also require changing `hhmm.invalid` and `hhmm.parse` to accept AM or
 
 Finally, for some good news: We can discard the `setEditorValue` and `getEditorValue` overrides.
 
-#### Intercepting keyboard input
-
-The _Dynamic Paradigm_ also requires that edits made to the text box be reflected in the GUI state.... _-- to be continued --_
-
-....
-
 ### Graphical editors
 
 Purely graphical editors (with no text box) would descend directly from `CellEditor`.
 
 One thing to keep in mind about these is that while the dimensions of the container element are automatically constrained to those of the cell, the child GUI elements can nonetheless be rendered by the browser _outside_ the div. This is useful when your GUI cannot all fit inside the cell boundaries. Just make sure the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/overflow|overflow} CSS property is set to `visible` (which is the default).
 
+### API
 
-_-- to be continued --_
+For detailed functional descriptions of overrideable methods, see {@link CellEditor}.
+ 

--- a/src/jsdoc/tutorials/cell-editors.md
+++ b/src/jsdoc/tutorials/cell-editors.md
@@ -255,7 +255,13 @@ There are two design paradigms for a complex cell editor with a text box differ 
 * **Dynamic Paradigm:** User interactions with the graphical elements during editing instantaneously update the text being edited. On save, the text element can be editable or it can be read-only. As the text element contains all the information, it is validated and parsed as usual.
 * **Delayed Paradigm:** User interactions with the graphical elements during editing do not affect the text. On save, the information from the state of the graphical elements is combined with the text data before parsing or transforms the primitive data after parsing.
 
-We shall further develop our `Time` cell editor by keeping the text input element but adding an AM/PM indicator that toggles on a mouse click. This example shall use the second design strategy mentioned above: The text input element is for the time in 12-hour mode, and the AM/PM indicator has no effect on the text.
+We shall now further develop our `Time` cell editor example:
+* We're going to show the time as 12-hour time with AM and PM rather than as 24-hour time.
+* Rather than typing AM or PM, user will click on it to toggle it.
+
+_NOTE: This is just an example for illustrative purposes. I'm not suggesting it's a practical user interface._
+
+We keep the text input element and add an AM/PM indicator to it's right that toggles on a mouse click. This example uses the _Delayed Paradigm_ outlined above: The text input element holds just the time in 12-hour mode; the AM/PM indicator is not part of the text and clicking it has no effect on the text.
 
 The following markup for a complex cell editor consists of a `<div>` containing an `<input>` element along with some text: 
 
@@ -410,7 +416,40 @@ respectively.
 
 #### Saving GUI state: Dynamic Paradigm
 
-Using event listeners, ... _-- to be continued --_
+The _Dynamic Paradigm_ as outlined above means that the GUI elements hold state that is always reflected in the contents of the text element.
+
+For our `Time` cell editor, this means that the AM or PM would be inside the text element. The user can edit it as text, or he could click the control to toggle it.
+ 
+_NOTE: On a practical level, the GUI should no longer be a piece of text because the AM or PM would appear doubled (once in the text box and again to its right). Perhaps a checkbox to indicate afternoon/evening instead._
+
+For this to work correctly requires _two-way binding_ between the GUI elements and text, meaning that:
+1. User's changes to the GUI state instantaneously affect the text; and
+2. User's edits to the text instantaneously affect the GUI state.
+ 
+This requires adding logic as needed to your GUI element event handlers or listeners to express the element's state in the text. For example, we could add the following line to the end of the GUI handler developed above:
+
+```javascript
+this.input.value.replace(/(AM|PM)$/i, this.meridian.textContent);
+```
+
+You could obviously get much more elaborate than this, maintaining models and view-controllers for each GUI element, _etc.;_ if it were anything more complex than this, that might be a good idea.
+ 
+The base class is already listening for `keyup` events on the text element. To bind the text edit events to the GUI state, we could just add our code there. For example, we could say:
+
+```javascript
+Time.prototype.keyup = function(e) {
+    CellEditor.prototype.keyup.call(this, e);
+    
+    var meridian = this.input.value.match(/(AM|PM)$/i);
+    if (meridian) {
+        this.meridian = meridian[0].toUpperCase();
+    }
+}
+```
+
+This would also require changing `hhmm.invalid` and `hhmm.parse` to accept AM or PM.
+
+Finally, for some good news: We can discard the `setEditorValue` and `getEditorValue` overrides.
 
 #### Intercepting keyboard input
 

--- a/src/jsdoc/tutorials/cell-editors.md
+++ b/src/jsdoc/tutorials/cell-editors.md
@@ -30,9 +30,9 @@ Programmatically, by overriding the declared assignment at render time:
 dataModel.getCellEditorAt = function(columnIndex, rowIndex, declaredEditorName, options) {
     var editorName = declaredEditorName;
     if (...) {
-        editorName = 'textfield';
+        editorName = 'textfield'; // case-insensitive
     }
-    return grid.createCellEditor(editorName, options);
+    return grid.cellEditors.create(editorName, options);
 }
 ```
 
@@ -40,12 +40,12 @@ See the full {@link DataModel#getCellEditorAt|getCellEditorAt} API.
 
 #### Text Format
 
-Cell editors that present data in text form will respect the cell's `format` render property:
+Cell editors that present data in text form will respect the cell's `format` render property (used primarily by the cell renderer):
   
 ```javascript
 behavior.setColumnProperties(columnIndex, {
     editor: 'textfield',
-    format: 'number' // case-insensitive; primarily used by cell renderer
+    format: 'number' // also case-insensitive
 });
 ```
 
@@ -55,9 +55,9 @@ To override or ignore the declared format (`options.format`) at render time:
 dataModel.getCellEditorAt = function(columnIndex, rowIndex, declaredEditorName, options) {
     if (...) {
         options.format = 'number';  // override
-        options.format = undefined; // ignore
+        options.format = undefined; // ignore (falsy defers to cell editor's localizer)
     }
-    return grid.createCellEditor(declaredEditorName, options);
+    return grid.cellEditors.create(declaredEditorName, options);
 }
 ```
 
@@ -71,7 +71,7 @@ dataModel.getCellEditorAt = function(columnIndex, rowIndex, declaredEditorName, 
         options.variable1 = 'yada';
         options.vairable2 = 'blah';
     }
-    return grid.createCellEditor(declaredEditorName, options);
+    return grid.cellEditors.create(declaredEditorName, options);
 }
 ```
 
@@ -81,7 +81,7 @@ After instantiation, object and its generated DOM elements are accessible as sho
 
 ```javascript
 dataModel.getCellEditorAt = function(columnIndex, rowIndex, declaredEditorName, options) {
-    var cellEditor = grid.createCellEditor(declaredEditorName, options);
+    var cellEditor = grid.cellEditors.create(declaredEditorName, options);
     if (cellEditor && columnIndex === behavior.columnEnum.BIRTH_DATE) { // defined cell editors only!
         cellEditor.input.setAttribute('style', '...'); // actual input control
         cellEditor.el.setAttribute('title', '...'); // container (input control if no container)
@@ -90,30 +90,339 @@ dataModel.getCellEditorAt = function(columnIndex, rowIndex, declaredEditorName, 
 }
 ```
 
-**NOTE:** Always check the return value from `createCellEditor` in case the editor name was unregistered.
+**NOTE:** Always check the return value from `cellEditors.create` in case the editor name was unregistered.
 
 #### Data coordinates in `getCellEditorAt`
 
 `columnIndex` is the position of the column in the `fields` array, which is derived from the data source. As such its order is undefined. Compare against members of the `behavior.columnEnum` map as illustrated above. Keys in this enum are all upper case with underscores inserted between camelCase words ("CAMEL_CASE"). (Although syntactically convenient and efficient, be aware that `columnEnum` is recreated on every call to `behavior.createColumns()` which is called by `behavior.setData()`. Local references will need to be updated at that time.)
 
-`options.column.name` contains the actual (case-sensitive) column name and is a convenient (though less efficient) alternative to dealing with `columnIndex` at all.
+As an alternative to dealing with `columnIndex` at all, `options.column.name` contains the actual column name.
  
-`rowIndex` is the position of data row, offset by the number of header rows (which includes the filter row).
+`rowIndex` is the position in the data row, offset by the number of header rows (all the rows above the first data row, including the filter row).
 
-### Predefined Cell Editors
+### Preregistered Cell Editors
 
-See each for its template and notes on browser limitations.
+The following cell editors are preregistered in `grid.cellEditors`. See each for its template and notes on browser limitations.
 
-{@link http://openfin.github.io/fin-hypergrid/doc/Color.html|Color},    
-{@link http://openfin.github.io/fin-hypergrid/doc/ComboBox.html|ComboBox}, 
-{@link http://openfin.github.io/fin-hypergrid/doc/Date.html|Date},  
-{@link http://openfin.github.io/fin-hypergrid/doc/Number.html|Number},
-{@link http://openfin.github.io/fin-hypergrid/doc/Slider.html|Slider},
-{@link http://openfin.github.io/fin-hypergrid/doc/Spinner.html|Spinner},  
-{@link http://openfin.github.io/fin-hypergrid/doc/Textfield.html|Textfield}.
+* {@link http://openfin.github.io/fin-hypergrid/doc/Color.html|Color},
+* {@link http://openfin.github.io/fin-hypergrid/doc/ComboBox.html|ComboBox},
+* {@link http://openfin.github.io/fin-hypergrid/doc/Date.html|Date},
+* {@link http://openfin.github.io/fin-hypergrid/doc/Number.html|Number},
+* {@link http://openfin.github.io/fin-hypergrid/doc/Slider.html|Slider},
+* {@link http://openfin.github.io/fin-hypergrid/doc/Spinner.html|Spinner},
+* {@link http://openfin.github.io/fin-hypergrid/doc/Textfield.html|Textfield}.
 
-### Custom Cell Editors
+### Development
 
-All cell editors extend `CellEditor`.
+Custom cell editor development falls into two broad classes:
+* General (graphical) editors &mdash; extend from `CellEditor`
+* Text editors &mdash; extend from {@link Textfield} (which extends from `CellEditor`)
+
+Development of **text-based cell editors** is relatively simple because they consist of a single `<input>` element and use localizers (formatters/de-formatters) to do the heavy lifting.
+
+#### Get the {@link Textfield} base class
+
+All custom text cell editors extend from the {@link Textfield} constructor. Since {@link Textfield} is preregistered in `grid.cellEditors`, it is easily accessible via `get`:
+
+```javascript
+var Textfield = grid.cellEditors.get('textfield');
+```
+
+If your using the npm module with Browserify, you can also do:
+
+```javascript
+var Textfield = require('fin-hypergrid/src/cellEditors/Textfield');
+```
+
+#### Create a new cell editor constructor
+
+Here's a simple extension of {@link Textfield} that limits input to 5 chars (for _hh:mm_) by modifying the template:
+
+```javascript
+var template = Textfield.prototype.template.replace(' ', ' maxlength="5" ');
+
+var Time = Textfield.extend('Time', { // optional class name aids debugging
+    template: template
+});
+```
+
+(See {@link http://github.com/joneit/extend-me} for details on the `extend` method.)
+
+#### Registration
+
+Register your new cell editor to make it accessible by name for easy assignment (as discussed above):
+
+```javascript
+grid.cellEditors.add(Time); // omitting name uses class name
+grid.cellEditors.add('Time', Time); // specify a name if class was not named
+```
+
+#### Localizers/Formatters
+
+Formatters are contained within localizers which are objects that are languistically and regionally sensitive to alphabet, numbering systems, notation for numbers and date, etc. Localizers know how to:
+ * Format primitive types into human-friendly form.
+ * De-format (parse) edited values back into primitive types.
+ * Optional: Validate edits that they conform to the format.
+
+Localizers are APIs (not instantiated objects) with both `format` and `parse` methods. Cell editors use both these methods. (Cell renderers also usew localizers but only use the `format` method.)
+
+To load and edit the data in the _hh:mm_ format, we will use the `hhmm` localizer. (See the example in the full _{@tutorial localization}_ tutorial.) First make sure to register it (so it can be referenced by name):
+
+```javascript
+grid.localization.add('hh:mm', hhmm); // name may be omitted when included in localizer
+```
+
+If we can guarantee our custom `Time` cell editor will only be used on columns that already render data in the _hh:mm_ format, then we're done because the cell editor will by default import the column's format. In this case the following is sufficient:
+  
+```javascript
+grid.behavior.setColumnProperties(columnIndex, {
+    editor: 'time',
+    format: 'hh:mm' // used by both cell renderer and cell editor
+});
+```
+
+Cell render format and edit format do not have to match, however. For example, to render the raw data without formatting (total minutes) but still edit in _hh:mm_ format:
+
+```javascript
+grid.behavior.setColumnProperties(columnIndex, {
+    editor: 'time'
+});
+
+var Time = Textfield.extend({
+    localizer: 'hh:mm',
+    template: template
+});
+```
+
+Or you can specify distinct formatters for rendering _vs._ editing:
+
+```javascript
+grid.behavior.setColumnProperties(columnIndex, {
+    editor: 'time',
+    format: '00h00m' // used only by cell renderer
+});
+
+var Time = Textfield.extend({
+    localizer: 'hhmm',
+    format: null, // lock localizer from being overwritten with 00h00m
+    template: template
+});
+```
+
+#### Validation
+
+Without validation, data may be saved incorrectly or not at all. With validation, the user is informed of the problem and has the opportunity to correct it.
+
+Validation is provided by the localizer in an {@link localizerInterface#invalid|invalid} method. See `hhmm`'s implementation of `invalid()` for an example.
+
+The localizer's `invalid` method is called automatically by the cell editor's {@link CellEditor#validateEditorValue|validateEditorValue} method, returning `true` or an error message on validation failure.
+
+Alternatively, you can override `validateEditorValue` with your own logic that doesn't depend on the localizer.
+
+#### Feedback
+
+Validation failure triggers an _error effect,_ giving the user the opportunity to re-edit the value instead of just discarding it and closing.
+
+Specifically, the cell editor its {@link CellEditor#errorEffectBegin|errorEffectBegin} method with the error message. This in turn calls the error effect function in {@link CellEditor#errorEffect|errorEffect} which is {@link module:effects.shaker|shaker} by default.
+
+After every third failure in an editing session, an alert is displayed:
+
+<pre style="font-family:monospace;margin:0 3em;padding:1em;border:1px solid grey;background:#DDD">
+Invalid value. To resolve, do one of the following:
+
+    * Correct the error and try again.
+        - or -
+    * Cancel editing by pressing the "esc" (escape) key.
+</pre>
+
+If an error message was returned by `invalid` and/or the localizer has a defined {@link localizerInterface#expectation|expectation} message, they will be included in the alert:
+
+<pre style="font-family:monospace;margin:0 3em;padding:1em;border:1px solid grey;background:#DDD">
+Additional information about this error:
+
+    * Error message (if there is one) would go here.
+
+    * Expectation message (if defined) would go here.
+</pre>
+
+Note that multiple lines become separate bullet points.
+
+### Complex cell editors
+
+Cell editors can be arbitrarily complex. Instead of a simple `<input>` element, the cell editor's template can be a container element, which can contain any kind of GUI you can imagine &mdash; with or without text input.
+ 
+There are two design paradigms for a complex cell editor with a text box differ in whether or not they modify the text being edited:
+* **Dynamic Paradigm:** User interactions with the graphical elements during editing instantaneously update the text being edited. On save, the text element can be editable or it can be read-only. As the text element contains all the information, it is validated and parsed as usual.
+* **Delayed Paradigm:** User interactions with the graphical elements during editing do not affect the text. On save, the information from the state of the graphical elements is combined with the text data before parsing or transforms the primitive data after parsing.
+
+We shall further develop our `Time` cell editor by keeping the text input element but adding an AM/PM indicator that toggles on a mouse click. This example shall use the second design strategy mentioned above: The text input element is for the time in 12-hour mode, and the AM/PM indicator has no effect on the text.
+
+The following markup for a complex cell editor consists of a `<div>` containing an `<input>` element along with some text: 
+
+```html
+<div style="background-color:white; text-align:right; font-size:10px; padding-right:4px; font-weight:bold; border:1px solid black">
+    <input type="text" lang="{{locale}}" style="background-color:transparent; width:80%; height:100%; float:left; border:0; padding:0; font-family:monospace; font-size:11px; text-align:right; {{style}}">
+    AM
+</div>
+```
+
+_NOTE: In practice, a CSS class is preferred over in-line styles. Regardless, always preserve the mustache variables, include `{{style}}`._
+
+Because this cell editor includes a text box, we continue to extend from `Textfield`:
+
+```javascript
+var Time = Textfield.extend({
+    template: '<div> ... </div>'; // above markup
+});
+```
+
+Complex cell editors need to know the element that holds the value (because unlike as in a simple cell editor, the actual input element `input` and the root DOM element `el` _are no longer the same_):
+
+```javascript
+var Time = Textfield.extend({
+    template: template,
+    
+    initialize: function() {
+        this.input = this.el.querySelector('input'); // needed by various CellEditor methods
+    }
+});
+```
+
+We will also need...
+1. **Event handlers** &mdash; to flip AM/PM on a mouse click.
+2. **Method overrides** &mdash; additional logic to combine AM/PM with the 12-hour time in the text box.
+
+#### Add an event handler
+
+Listen for the mouseclick and toggle the graphic (AM -> PM -> AM ...):
+
+```javascript
+var Time = Textfield.extend({
+    template: template,
+    
+    initialize: function() {
+        this.input = this.el.querySelector('input');
+        this.meridian = this.el.querySelector('span'); // optional; just for our convenience 
+        
+        // Flip AM/PM on any click
+        this.el.onclick = function() {
+            this.meridian.textContent = this.meridian.textContent === 'AM' ? 'PM' : 'AM';  field
+        }.bind(this);
+        this.input.onclick = function(e) {
+            e.stopPropagation(); // ignore clicks in the text FIELD
+        };
+        
+        // nice-to-have: show outline on `el` rather than `input`
+        // alternatively, set `outline:0` on the input style and forget about it
+        this.input.onfocus = function(e) {
+            var target = e.target;
+            this.el.style.outline = this.outline = this.outline || window.getComputedStyle(target).outline;
+            target.style.outline = 0;
+        }.bind(this);
+        this.input.onblur = function(e) {
+            this.el.style.outline = 0;
+        }.bind(this);
+    }
+});
+```
+
+
+
+#### Update the localizer to 12-hour time
+
+Compare the following to the 24-hour time version in the _{@tutorial localization}_ tutorial:
+
+```javascript
+var hhmm = {
+    // returns formatted string from number
+    format: function(mins) {
+        var hh = Math.floor(mins / 60) % 12 || 12, // modulo 12 hrs with 0 becoming 12
+            mm = (mins % 60 + 100 + '').substr(1, 2);
+        return hh + ':' + mm;
+    },
+    
+    invalid: function(hhmm) {
+        return !/^(0?[1-9]|1[0-2]):[0-5]\d$/.test(hhmm); // 12:59 max
+    },
+    
+    // returns number from formatted string
+    parse: function(hhmm) {
+        var parts = hhmm.match(/^(\d+):(\d{2})$/);
+        return Number(parts[1]) * 60 + Number(parts[2]);
+    }
+};
+```
+
+#### Loading GUI state
+
+The state of the graphical elements needs to be loaded (set) at the beginning of an edit session, as implied by the primitive data. In this example, the only GUI element is the AM/PM toggle, set based on the time's relation to noon.
+
+GUI elements are initialized by overriding the {@link CellEditor#setEditorValue|setEditorValue} method:
+
+```javascript
+var NOON = 12 * 60;
+
+Time.prototype.setEditorValue = function(value) {
+    this.input.value = this.localizer.format(value); // pasted in from base class implementation
+    this.el.textContent = value < NOON ? 'AM' : 'PM';
+};
+```
+
+#### Saving GUI state: Delayed Paradigm
+
+For the _Delayed Paradigm_ only, GUI state needs to be saved at the conclusion of an edit session but before saving. This is done by overriding the {@link CellEditor#setEditorValue|setEditorValue} method.
+
+The GUI state is inspected and used used to either:
+1. **Decorate the text** input before it is run through the parser; or
+2. **Transform the data** primitive coming out of the parser.
+
+This example uses the _Delayed Paradigm_ so the state of the AM/PM toggle is saved at the conclusion of editing by transforming the data. Specifically, 12 hours is added for afternoon values only:
+    
+```javascript
+Time.prototype.getEditorValue = function(value) {
+    value = this.localizer.parse(this.input.value); // pasted in from base class implementation
+    if (this.el.textContent === 'PM') {
+        value += NOON;
+    }
+    return value;
+};
+```
+
+NOTE: Code pasted in above was for illustrative purposes. In practice, you might make direct calls to the base class methods instead:
+
+```javascript
+var CellEditor = grid.cellEditors.get('celleditor');
+```
+
+and replace commented lines above with:
+
+```javascript
+    CellEditor.prototype.setEditorValue.call(this, value);
+```
+
+and
+
+```javascript
+    value = CellEditor.prototype.getEditorValue.call(this, value);
+```
+
+respectively.
+
+#### Saving GUI state: Dynamic Paradigm
+
+Using event listeners, ... _-- to be continued --_
+
+#### Intercepting keyboard input
+
+The _Dynamic Paradigm_ also requires that edits made to the text box be reflected in the GUI state.... _-- to be continued --_
+
+....
+
+### Graphical editors
+
+Purely graphical editors (with no text box) would descend directly from `CellEditor`.
+
+One thing to keep in mind about these is that while the dimensions of the container element are automatically constrained to those of the cell, the child GUI elements can nonetheless be rendered by the browser _outside_ the div. This is useful when your GUI cannot all fit inside the cell boundaries. Just make sure the {@link https://developer.mozilla.org/en-US/docs/Web/CSS/overflow|overflow} CSS property is set to `visible` (which is the default).
+
 
 _-- to be continued --_

--- a/src/jsdoc/tutorials/localization.md
+++ b/src/jsdoc/tutorials/localization.md
@@ -3,6 +3,31 @@ The file ./src/lib/localization.js provides "localization agents" that know how 
   * Grid display
   * Cell editor pre-load
 * Standardize a localized string back into a typed primitive (or object) for writing back to a data row.
-* Check an edited localized string for illegal characters (implementation optional).
+* Check an edited localized string for syntax or just for illegal characters (implementation optional).
  
 The API includes factory functions that invoke the `Intl` API for numbers and dates. On instantiation, the singleton Localization object "constructs" basic `number` and `date` localizers using these factory functions. It also defines several other localizers (). You can also add your own custom localizers using the `grid.localization.add` method. For numbers and dates, use the factory functions. For other formats, supply an object that conforms to the localization API interface (has the required `format` and `parse` methods; and the optional `isValid` method).
+
+
+For illustration purposes, however, here's a simple implementation of this localizer:
+
+```javascript
+var hhmm = {
+    // returns formatted string from number
+    format: function(mins) {
+        var hh = Math.floor(mins / 60),
+            mm = (mins % 60 + 100 + '').substr(1, 2);
+        return hh + ':' + mm;
+    },
+    
+    // tests input for full validity
+    invalid: function(hhmm) {
+        return /^([01]?\d|2[0-3]):[0-5]\d$/.test(hhmm); // 23:59 max
+    },
+    
+    // returns number from formatted string
+    parse: function(hhmm) {
+        var parts = hhmm.match(/^(\d+):(\d{2})$/);
+        return Number(parts[1]) * 60 + Number(parts[2]);
+    }
+};
+```

--- a/src/lib/Localization.js
+++ b/src/lib/Localization.js
@@ -361,12 +361,17 @@ Localization.prototype = {
     /** @summary Register a localizer.
      * @desc Checks the provided localizer that it conforms to {@link localizerInterface}
      * and adds it to the object using localizerName all lower case as the key.
-     * @param {string} localizerName
+     * @param {string} name
      * @param {localizerInterface} localizer
      * @memberOf Localization.prototype
      * @returns {localizeInerface} The provided localizer.
      */
-    add: function(localizerName, localizer) {
+    add: function(name, localizer) {
+        if (typeof name === 'object') {
+            localizer = name;
+            name = undefined;
+        }
+
         if (
             typeof localizer !== 'object' ||
             typeof localizer.format !== 'function' ||
@@ -377,7 +382,9 @@ Localization.prototype = {
             throw 'Expected localizer object to conform to interface.';
         }
 
-        this[localizerName.toLowerCase()] = localizer;
+        name = name || localizer.name;
+        name = name && name.toLowerCase();
+        this[name] = localizer;
 
         return localizer;
     },
@@ -388,8 +395,8 @@ Localization.prototype = {
      * @returns {localizerInterface}
      * @memberOf Localization.prototype
      */
-    get: function(localizerName) {
-        return this[localizerName] || this.string;
+    get: function(name) {
+        return this[name && name.toLowerCase()] || this.string;
     },
 
     ///  ///  ///  ///  ///    LOCALIZERS    ///  ///  ///  ///  ///


### PR DESCRIPTION
grid.registerCellEditor -> grid.cellEditors.add
grid.createCellEditor -> grid.cellEditors.create
Made `name` parameter optional for cellEditors.add, cellRenderers.add, localization.add
Added "hh:mm" example to demo.js
Added new column Birth Time to widedata.js
Expanded cell editors tutorial