### PR TITLE
Remove selectAll on focus.

### DIFF
--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -392,7 +392,6 @@ var CellEditor = Base.extend('CellEditor', {
         el.style.left = el.style.top = 0; // work-around: move to upper left
 
         this.input.focus();
-        this.selectAll();
 
         el.style.left = leftWas;
         el.style.top = topWas;


### PR DESCRIPTION
See #181 

I think it would be best if you call `selectAll` only if it's a double click event.
I couldn't figure out how to do that.