### PR TITLE
GRID-235: Externalize hyper-analytics (first step)

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -63,9 +63,8 @@ function Hypergrid(div, options) {
     this.renderOverridesCache = {};
 
     options = options || {};
-    var data = typeof options.data === 'function' ? options.data() : options.data;
     var Behavior = options.Behavior || behaviors.JSON;
-    this.behavior = new Behavior(this, options.schema, data);
+    this.behavior = new Behavior(this, options.data, options);
 
     var loc = options.localization || {};
     this.localization = new Localization(
@@ -3343,12 +3342,14 @@ Hypergrid.prototype = {
         var filter = this.getGlobalFilter(),
             result;
 
-        if (filter.invalid()) {
-            result = 'error';
-        } else if (filter.filterCount()) {
-            result = 'active';
-        } else {
-            result = 'inactive';
+        if (filter) {
+            if (filter.invalid()) {
+                result = 'error';
+            } else if (filter.filterCount()) {
+                result = 'active';
+            } else {
+                result = 'inactive';
+            }
         }
 
         return result;

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -34,13 +34,10 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @desc this is the callback for the plugin pattern of nested tags
      * @param {Hypergrid} grid
-     * @param {function|menuItem[]} [schema=derivedSchema] - Passed to behavior constructor. May be:
-     * * A schema array
-     * * A function returning a schema array. Called at filter reset time with behavior as context.
-     * * Omit to generate a basic schema from `this.columns`.
+     * @param {object} [options] - _(See {@link behaviors.JSON#setData}.)_
      * @memberOf Behavior.prototype
      */
-    initialize: function(grid, schema, dataRows) {
+    initialize: function(grid, dataRows, options) {
         /**
          * @type {Hypergrid}
          * @memberOf Behavior.prototype

--- a/src/behaviors/JSON.js
+++ b/src/behaviors/JSON.js
@@ -20,14 +20,15 @@ var JSON = Local.extend('behaviors.JSON', {
      * > All `initialize()` methods in the inheritance chain are called, in turn, each with the same parameters that were passed to the constructor, beginning with that of the most "senior" class through that of the class of the new instance.
      *
      * @param grid - the hypergrid
-     * @param {undefined|function|menuItem[]} schema - Already consumed by Behavior's {@link Behavior#initialize|initialize}.
+     * @param {undefined|function|menuItem[]} options.schema - Already consumed by Behavior's {@link Behavior#initialize|initialize}.
      * @param {object[]} dataRows - May be:
      * * An array of congruent raw data objects
      * * A function returning same
+     * @param {object} [options] - _(See {@link behaviors.JSON#setData}.)_
      * @memberOf behaviors.JSON.prototype
      */
-    initialize: function(grid, schema, dataRows) {
-        this.setData(dataRows, schema);
+    initialize: function(grid, dataRows, options) {
+        this.setData(dataRows, options);
     },
 
     features: [
@@ -98,13 +99,20 @@ var JSON = Local.extend('behaviors.JSON', {
     /**
      * @memberOf behaviors.JSON.prototype
      * @description Set the data field.
-     * @param {object[]} dataRows - An array of uniform objects backing the rows in the grid.
+     * @param {function|object[]} dataRows - An array of uniform objects backing the rows in the grid.
+     * @param {object} [options]
+     * @param {function|object} [options.fields] - Passed as 2nd param to `this.dataModel.setData`.
+     * @param {function|object} [options.schema=deriveSchema] - Used in filter instantiation.
      */
     setData: function(dataRows, options) {
         var self = this,
-            grid = this.grid;
+            grid = this.grid,
+            fields = options && options.fields;
 
-        this.dataModel.setData(dataRows, options);
+        fields = typeof fields === 'function' ? fields() : fields;
+        dataRows = typeof dataRows === 'function' ? dataRows() : dataRows;
+
+        this.dataModel.setData(dataRows, fields);
         this.createColumns();
 
         this.schema = options && options.schema || deriveSchema;

--- a/src/cellEditors/FilterBox.js
+++ b/src/cellEditors/FilterBox.js
@@ -31,7 +31,7 @@ var FilterBox = ComboBox.extend('FilterBox', {
         // look in the filter, under column filters, for a column filter for this column
         var root = this.grid.getGlobalFilter(),
             columnName = this.column.name,
-            columnFilters = this.grid.getGlobalFilter().columnFilters,
+            columnFilters = root.columnFilters,
             columnFilterSubtree = root.getColumnFilter(columnName) || {},
             columnSchema = root.schema.lookup(columnName) || {};
 


### PR DESCRIPTION
dataModel/JSON.js:
- Now functions without aggregator or filter data sources.
- setData now re-uses previous data source if dataSource (1st param) is omitted.
- setData now passes 2nd param to constructor of first data source in the pipeline.

behaviors/Behavior.js, behaviors/JSON.js:
Changed calling signature for constructor (initialize method) from (grid, schema, dataRows) to (grid, dataRows, options).
Added options.fields, passed to dataMode/JSON.setData as 2nd param.