### PR TITLE
fix: fixes TypeError due to accessing out-of-bounds columns

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1257,7 +1257,7 @@ Hypergrid.prototype = {
 
         this.stopEditing(); //other editor is open, close it first
 
-        if (editPoint.x >= 0 && editPoint.y >= 0) {
+        if (editPoint.x >= 0 && editPoint.y >= 0 && editPoint.x < this.getColumnCount()) {
             var editable = this.behavior.getActiveColumn(editPoint.x).getProperties().editable;
             if (editable || this.isFilterRow(editPoint.y)) {
                 this.setMouseDown(editPoint);


### PR DESCRIPTION
Currently if you have a grid that has empty space to the right of the columns, the following error occurs on double-click:

```
Hypergrid.js:1261 Uncaught TypeError: Cannot read property 'getProperties' of undefinededitAt @ Hypergrid.js:1261
```

This fixes the issue by ensuring that the `editPoint` column is within the expected range