### PR TITLE
GRID-308: Invalid operator

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -108,7 +108,7 @@ window.onload = function() {
     }
 
     var customSchema = [
-        { name: 'last_name', type: 'number', opMenu: ['=', '<', '>'] },
+        { name: 'last_name', type: 'number', opMenu: ['=', '<', '>'], opMustBeInMenu: true },
         { name: 'total_number_of_pets_owned', type: 'number' },
         { name: 'height', type: 'number' },
         'birthDate',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "automat": "1.2.0",
     "extend-me": "2.2.4",
-    "filter-tree": "0.3.35",
+    "filter-tree": "0.3.36",
     "finbars": "1.5.1",
     "fincanvas": "1.3.0",
     "hyper-analytics": "0.11.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "automat": "1.2.0",
     "extend-me": "2.2.4",
-    "filter-tree": "0.3.34",
+    "filter-tree": "0.3.35",
     "finbars": "1.5.1",
     "fincanvas": "1.3.0",
     "hyper-analytics": "0.11.8",

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -241,7 +241,7 @@ var CellEditor = Base.extend('CellEditor', {
             this.grid.selectViewportCell(point.x, point.y - this.grid.getHeaderRowCount());
             this.errorEffectBegin(++this.errors % feedback === 0 && error);
         } else { // invalid but no feedback
-            return this.cancelEditing();
+            this.cancelEditing();
         }
 
         return !error;

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -221,7 +221,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
         } else if (isHeaderRow && y === 0) {
             return this._setHeader(x, value);
         } else if (isFilterRow) {
-            this.setFilter(x, value, { alert: true });
+            this.setFilter(x, value);
         } else {
             return this._setHeader(x, value);
         }

--- a/src/filter/DefaultFilter.js
+++ b/src/filter/DefaultFilter.js
@@ -335,7 +335,7 @@ var DefaultFilter = FilterTree.extend('DefaultFilter', {
                     state = this.parseStateString(state, options); // because .add() only takes object syntax
                     subexpression = this.columnFilters.add(state);
                 }
-                options.throw = true;
+
                 error = subexpression.invalid(options);
             }
         }

--- a/src/filter/parser-CQL.js
+++ b/src/filter/parser-CQL.js
@@ -44,7 +44,12 @@ function ParserCQL(operatorsHash, options) {
     operators = operators.sort(descendingByLength);
 
     // Escape all symbolic (non alpha) operators.
-    operators = operators.map(function(op) { return /[^\w]/.test(op) ? '\\' + op.split('').join('\\') : op; });
+    operators = operators.map(function(op) {
+        if (/^[^A-Z]/.test(op)) {
+            op = '\\' + op.split('').join('\\');
+        }
+        return op;
+    });
 
     var symbolicOperators = operators.filter(function(op) { return op[0] === '\\'; }),
         alphaOperators = operators.filter(function(op) { return op[0] !== '\\'; }).join('|');


### PR DESCRIPTION
Resolved by allowing operator synonyms even though not in menu proper.

Also added a property `opMustBeInMenu` to constrain typed-in op validity to menu.