### PR TITLE
Version history 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <img src="images/README/gridshot04.gif">
 
-### Current Release (1.0.8 - 8 August 2016)
+### Current Release (1.0.9 - 29 August 2016)
 
-The current version replaces last year's [prototype version](https://github.com/openfin/fin-hypergrid/tree/polymer-prototype), which was built around Polymer. It is now completely "de-polymerized" and is being made available as:
+The current version 1.0 replaces last year's [prototype version](https://github.com/openfin/fin-hypergrid/tree/polymer-prototype), which was built around Polymer. It is now completely "de-polymerized" and is being made available as:
 * An [npm module](https://www.npmjs.com/package/fin-hypergrid) for use with browserify.
 * A single JavaScript file [fin-hypergrid.js](https://openfin.github.io/fin-hypergrid/build/fin-hypergrid.js) you can reference in a `<script>` tag.
 
@@ -30,11 +30,13 @@ Check out the Table view on Hyperblotter on a Windows machine via [this installe
 
 ![](https://github.com/openfin/fin-hypergrid/blob/master/images/README/Hypergrid%20Features.png)
 
-###### The Filtering & Analytics (sorting & aggregation) modules provided will be broken out of Hypergrid
+##### Future development
 
-* We are currently working on expanding the API to enable application developers to easily provide their own functionality
-* Hypergrid will have no opinion on how the underlying data should be pivoted, but will remain capable of presenting pivoted data
-* The current filtering and analytics modules will become separate npm modules/JavaScript files that can be forked and further developed
+* We are currently working on expanding the API to enable application developers to easily provide their own functionality.
+* Hypergrid will have no opinion on how the underlying data should be pivoted, but will remain capable of presenting pivoted data.
+* For local data transformations, the current sorting, filtering, _etc.,_ modules will be unbundled from the Hypergrid build and published as external modules, along with full API docs so you can roll your own.
+* Remote data transformations will be supported with all the eventing necessary for triggering such transformations on a remote server.
+* Drill-downs, currently implemented for local tree view, group view, and aggregated data view, will be supported for remote data as well.
 
 ### Integrating
 
@@ -89,4 +91,4 @@ Hypergrid global configurations can be found [here](http://openfin.github.io/fin
 ### Contributors
 
 Developers interested in contributing to this project should submit pull requests against the `develop` branch.
-We have several beginner `help wanted` [tickets](https://github.com/openfin/fin-hypergrid/issues) open for community involvement
+We have several beginner `help wanted` [tickets](https://github.com/openfin/fin-hypergrid/issues) open for community involvement.

--- a/add-ons/row-by-id.js
+++ b/add-ons/row-by-id.js
@@ -3,12 +3,167 @@
 /**
  * Mix into your data model for get/modify/delete access to rows by single- or multi-column ID.
  *
- * These functions are all simple wrappers for the heavily overloaded {@link http://openfin.github.io/hyper-analytics/DataSource.html#findRow|DataSource.prototype.findRow} method.
+ * These functions are all basically wrappers for the heavily overloaded {@link http://openfin.github.io/hyper-analytics/DataSource.html#findRow|DataSource.prototype.findRow} method.
  *
  * ### Usage
  *
+ * ##### Client-side install with `<script>` tag
+ * 1. In `<head>...</head>` element, include <u>only one or the other</u> of the following (after including Hypergrid itself):
+ * ```html
+ * <script src="build/add-ons/row-by-id.js"></script>
+ * <script src="build/add-ons/row-by-id.min.js"></script>
+ * ```
+ * 2. In a `<script>...</script>` element:
  * ```javascript
  * rowById.mixInTo(MyDataModel.prototype);
+ * ```
+ *
+ * ##### Browserify integration with `require()`
+ * ```javascript
+ * var rowById = require('./add-ons/rowById');
+ * ...
+ * robById.mixInTo(myGrid.behavior.dataModel);
+ * ```
+ *
+ * ##### Note
+ *
+ * The above code access methodologies reference two different files:
+ * * The built version comes from ./build/add-ons and the API is assigned to `window.fin.Hypergrid.rowById`
+ * * The repo version comes from ./add-ons and the API is assigned to `module.exports`
+ *
+ * ### Examples
+ *
+ * _Instructions:_ You can try the examples below by going to [rowById.html](http://openfin.github.io/fin-hypergrid/rowById.html). This page is identical to [rowById.html](http://openfin.github.io/fin-hypergrid/example.html) _except_ with the addition of the above client-side install and mix-in lines. Then copy & paste each of the following code blocks into Chrome's developer console and hit the return key, observing the changes to the grid as you do so.
+ *
+ * 1. Set up some variables:
+ * ```javascript
+ * var behavior = grid.behavior;
+ * var dataModel = behavior.dataModel;
+ * var findKey = "symbol";
+ * var findVal = 'FB';
+ * ```
+ * 2. Add a new row:
+ * ```javascript
+ * var newDataRow = {};
+ * newDataRow[findKey] = findVal;
+ * newDataRow.name = 'Facebook';
+ * newDataRow.prevclose = 125.08;
+ * dataModel.addRow(newDataRow);
+ * // To see the new row you must (eventually) call:
+ * behavior.applyAnalytics();
+ * grid.behaviorChanged();
+ * ```
+ * 3. Modify an existing row:
+ * ```javascript
+ * var modKey = 'name';
+ * var modVal = 'Facebook, Inc.';
+ * var dataRow = dataModel.modifyRowById(findKey, findVal, modKey, modVal);
+ * // To see the modified cells you must (eventually) call:
+ * behavior.applyAnalytics();
+ * grid.repaint();
+ * ```
+ * 4. Delete (remove) a row:
+ * ```javascript
+ * var oldRow = dataModel.deleteRowById(findKey, findVal);
+ * // To see the row disappear you must (eventually) call:
+ * behavior.applyAnalytics();
+ * grid.behaviorChanged();
+ * ```
+ * 5. Replace an existing row:
+ * ```javascript
+ * findVal = 'MSFT';
+ * var newRow = {symbol: "ABC", name: "Google", prevclose: 666};
+ * var oldRow = dataModel.replaceRowById(findKey, findVal, newRow);
+ * // To see the row change you must (eventually) call:
+ * behavior.applyAnalytics();
+ * grid.repaint();
+ * ```
+ * This replaces the row with the new row object, returning but otherwise discarding the old row object. That is, the new row object takes on the ordinal of the old row object. By contrast, modifyDataRow keeps the existing row object, updating it in place.
+ *
+ * 6. Fetch a row (find the row and return the row object):
+ * ```javascript
+ * findVal = 'ABC';
+ * var dataRow = dataModel.getRowById(findKey, findVal);
+ * ```
+ * 7. Get a row's index (find the row and return its ordinal) (for use with Hypergrid's various grid coordinate methods):
+ * ```javascript
+ * var rowIndex = dataModel.getRowIndexById(findKey, findVal);
+ * ```
+ * 8. Erase (blank) a row:
+ * ```javascript
+ * var oldRow = dataModel.eraseRowById(findKey, findVal);
+ * // To see the row blank you must (eventually) call:
+ * grid.behavior.applyAnalytics();
+ * grid.repaint();
+ * ```
+ *
+ * ### Notes
+ *
+ * ##### Updating the rendered grid
+ *
+ * The following calls should be made sparingly as they can be expensive. The good news is that they only need to be called at the very end of a batch grid data changes.
+ *    1. Call `grid.behavior.applyAnalytics()`. This call does nothing when the data source pipeline is empty. Otherwise, applies each data source transformations (filter, sort) in the pipeline. Needed when adding, deleting, or modifying rows.
+ *    2. Call `grid.behaviorChanged()` when the number of rows (or columns) changes as a result of the data alteration.
+ *    3. Call `grid.repaint()` when cells are updated in place. Note that `behaviorChanged` calls `repaint` for you so you only need to call one or the other.
+ *
+ * ##### Search key hash option
+ *
+ * Search key(s) may be provided in a single hash parameter instead of in two distinct parameters (_à la_ underscore.js)
+ *
+ * For any of the methods above that take a search key, the first two arguments (`findkey` and `findVal`) may be replaced with a single argument `findHash`, a hash of key:value pairs, optionally followed by a 2nd argument `findList`, a _whitelist_ (an array) of which keys in `findHash` to use. These overloads allow for searching based on multiple columns:
+ *
+ * ###### Example 1
+ * Single-column primary key:
+ * ```javascript
+ * behavior.getRow({ symbol: 'FB' });
+ * ```
+ * ###### Example 2
+ * Multi-column primary key (target row must match all keys):
+ * ```javascript
+ * behavior.getRow({ symbol: 'FB', name: 'Facebook' });
+ * ```
+ * ###### Example 3
+ * Limit the column(s) that comprise the primary key with `findList`, an array of allowable search keys:
+ * ```javascript
+ * var findWhiteList = ['symbol'];
+ * behavior.getRow({ symbol: 'FB', name: 'the facebook' }, findKeyList);
+ * ```
+ * In the above example, name is ignored because it is absent from the key list. This example is therefore functionally equivalent to example 2.a.
+ *
+ * ##### Modifications hash option
+ *
+ * Field(s) to modify may be provided in a hash instead (_à la_ jQuery.js)
+ *
+ * This overload allows for updating multiple columns of a row with a single method call:
+ * ```javascript
+ * var modHash = { name: 'Facebook, Inc.', prevclose: 125};
+ * dataModel.modifyRowById('symbol', 'FB', modHash);
+ * ```
+ * The above is equivalent to the following separate calls which each update a specific field in the same row:
+ * ```javascript
+ * dataModel.modifyRowById('symbol', 'FB', 'name', 'Facebook, Inc.');
+ * dataModel.modifyRowById('symbol', 'FB', 'prevclose', 125);
+ * ```
+ * Normally all included fields will be modified. As in `findList` (described above), you can limit which fields to actually modify by providing an additional parameter `modList`, an array of fields to modify. The following example modifies the "prevClose" field but not the "name" field:
+ * ```javascript
+ * var modWhiteList = ['prevclose'];
+ * dataModel.modifyRowById('symbol', 'FB', modHash, modWhiteList);
+ * ```
+ *
+ * ##### Summary
+ *
+ * The overloads discussed above in _Search key hash option_ and _Modifier hash option_ may be combined. For example, the full list of overloads for {@link rowById.modifyRowById} is:
+ *
+ * ```javascript
+ * behavior.modifyRowById(findKey, findVal, modKey, modVal);
+ * behavior.modifyRowById(findKey, findVal, modHash);
+ * behavior.modifyRowById(findKey, findVal, modHash, modWhiteList);
+ * behavior.modifyRowById(findHash, modKey, modVal);
+ * behavior.modifyRowById(findHash, modHash);
+ * behavior.modifyRowById(findHash, modHash, modWhiteList);
+ * behavior.modifyRowById(findHash, findWhiteList, modKey, modVal);
+ * behavior.modifyRowById(findHash, findWhiteList, modHash);
+ * behavior.modifyRowById(findHash, findWhiteList, modHash, modWhiteList);
  * ```
  *
  * @mixin
@@ -16,9 +171,7 @@
 var rowById = {
     /**
      * @summary Remove the ID'd data row object from the data store.
-     * @desc This removes the row from the grid. It is no longer rendered.
-     *
-     * Reminder: To see the deletion in the grid, you must eventually call:
+     * @desc If data source pipeline in use, to see the deletion in the grid, you must eventually call:
      * ```javascript
      * this.grid.behavior.applyAnalytics();
      * this.grid.behaviorChanged();
@@ -41,7 +194,7 @@ var rowById = {
      * @summary Undefine the ID'd row object in place.
      * @desc Similar to {@link rowById.deleteRowById|deleteRowById} except leave an `undefined` in place of data row object. This renders as a blank row in the grid.
      *
-     * Reminder: To see the deletion in the grid, you must eventually call:
+     * If data source pipeline in use, to see the deletion in the grid, you must eventually call:
      * ```javascript
      * this.grid.behavior.applyAnalytics();
      * this.grid.behaviorChanged();
@@ -60,8 +213,13 @@ var rowById = {
     },
 
     /**
-     * @param keyOrHash
-     * @param valOrList
+     * @param {object|string} keyOrHash - One of:
+     * * _string_ - Column name.
+     * * _object_ - Hash of 0 or more key-value pairs to search for.
+     * @param {*|string[]} [valOrList] - One of:
+     * _omitted_ - When `keyOrHash` is a hash and you want to search all its keys.
+     * _string[]_ - When `keyOrHash` is a hash but you only want to search certain keys.
+     * _otherwise_ - When `keyOrHash` is a string. Value to search for.
      * @returns {number}
      */
     getRowIndexById: function(keyOrHash, valOrList) {
@@ -70,8 +228,13 @@ var rowById = {
     },
 
     /**
-     * @param keyOrHash
-     * @param valOrList
+     * @param {object|string} keyOrHash - One of:
+     * * _string_ - Column name.
+     * * _object_ - Hash of 0 or more key-value pairs to search for.
+     * @param {*|string[]} [valOrList] - One of:
+     * _omitted_ - When `keyOrHash` is a hash and you want to search all its keys.
+     * _string[]_ - When `keyOrHash` is a hash but you only want to search certain keys.
+     * _otherwise_ - When `keyOrHash` is a string. Value to search for.
      * @returns {object}
      */
     getRowById: function(keyOrHash, valOrList) {
@@ -79,8 +242,8 @@ var rowById = {
     },
 
     /**
-     * @summary Update selected columns in ID'd data row.
-     * @desc Reminder: To see the deletion in the grid, you must eventually call:
+     * @summary Update selected columns in existing data row.
+     * @desc If data source pipeline in use, to see the deletion in the grid, you must eventually call:
      * ```javascript
      * this.grid.behavior.applyAnalytics();
      * this.grid.repaint();
@@ -129,8 +292,9 @@ var rowById = {
 
     /**
      * @summary Replace entire ID'd row object with another.
-     * @desc The replacement may or may not have the same ID as the row object being replaced.
-     * Reminder: To see the replaced row in the grid, you must eventually call:
+     * @desc The replacement may have (but does not have to have) the same ID as the row object being replaced.
+     *
+     * If data source pipeline in use, to see the replaced row in the grid, you must eventually call:
      * ```javascript
      * this.grid.behavior.applyAnalytics();
      * this.grid.behaviorChanged();
@@ -163,10 +327,10 @@ function getByIdArgs(keyOrHash, valOrList) {
 
 /**
  * @name mixInTo
- * @summary Mix all the `rowById` members into the given target object.
- * @desc The target object is intended to be Hypergrid's in-memory data model object (./src/dataModels/JSON.js).
+ * @summary Mix all the other members into the given target object.
+ * @desc The target object is intended to be Hypergrid's in-memory data model object ({@link dataModels.JSON}).
  *
- * _NOTE:_ This `mixInTo` method is excluded (not mixed in, because it is non-enumerable).
+ * **NOTE:** This `mixInTo` method is defined here rather than above just so that it will be non-enumerable and therefore not itself mixed into the `target` object.
  * @function
  * @param {object} target - Your data model instance or its prototype.
  * @memberOf rowById

--- a/demo/example.html
+++ b/demo/example.html
@@ -8,7 +8,6 @@
     <div id="fin-grid"></div>
 
     <script src="build/fin-hypergrid.js"></script>
-    <script src="build/add-ons/row-by-id.js"></script>
 
     <script>
 var data = [
@@ -18,7 +17,7 @@ var data = [
     { symbol: 'IBM', name: 'International Business Machines Corp', prevclose: 155.35 }
 ];
 
-var grid = new fin.Hypergrid('#fin-grid', { data: data })
+var grid = new fin.Hypergrid('#fin-grid', { data: data });
 
 grid.addProperties({
     showRowNumbers: false,

--- a/demo/js/tree-view-separate-drill-down.js
+++ b/demo/js/tree-view-separate-drill-down.js
@@ -39,6 +39,10 @@ window.onload = function() {
         showFilterRow: pipelineOptions.includeFilter
     });
 
+    grid.behavior.setColumnProperties(grid.behavior.columnEnum.STATE, {
+        halign: 'left'
+    });
+
     // In order for the the State column to not sort the leaves (city names), we want it to use the "depth sorter" rather than the regular sorter used by the other columns. To make this work, the column does need to be called out when it differs from the tree (drill-down) column. In this demo, those columns are separate. We do this using the groupColumn (which normally defaults to whatever the tree column is set to).
     var treeViewOptions = { groupColumn: 'State' },
         treeView = new TreeView(grid, treeViewOptions),
@@ -58,22 +62,10 @@ window.onload = function() {
 
             dd.unsortable = dd.column.getProperties().unsortable;
             dd.column.getProperties().unsortable = true;
-
-            grid.behavior.dataModel.getCell = getCell;
         } else {
             dd.column.header = dd.header;
             dd.column.getProperties().unsortable = dd.unsortable;
-            delete grid.behavior.dataModel.getCell;
         }
     };
-
-    function getCell(config, rendererName) {
-        if (config.isUserDataArea) {
-            if (config.x === idx.NAME) {
-                config.halign = 'left';
-            }
-        }
-        return grid.cellRenderers.get(rendererName);
-    }
 };
 

--- a/demo/js/tree-view.js
+++ b/demo/js/tree-view.js
@@ -32,6 +32,10 @@ window.onload = function() {
         showFilterRow: pipelineOptions.includeFilter
     });
 
+    grid.behavior.setColumnProperties(grid.behavior.columnEnum.STATE, {
+        halign: 'left'
+    });
+
     var treeViewOptions = { treeColumn: 'State' }, // groupColumn option defaults to treeColumn (or its default)
         treeView = new TreeView(grid, treeViewOptions);
 
@@ -41,20 +45,7 @@ window.onload = function() {
     }
 
     document.querySelector('input[type=checkbox]').onclick = function() {
-        if (treeView.setRelation(this.checked, true)) {
-            grid.behavior.dataModel.getCell = getCell;
-        } else {
-            delete grid.behavior.dataModel.getCell;
-        }
+        treeView.setRelation(this.checked, true);
     };
-
-    function getCell(config, rendererName) {
-        if (config.isUserDataArea) {
-            if (config.x === grid.behavior.columnEnum.STATE) {
-                config.halign = 'left';
-            }
-        }
-        return grid.cellRenderers.get(rendererName);
-    }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Canvas-based high-performance spreadsheet",
   "repository": {
     "type": "git",

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -823,7 +823,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
 
     /**
      * @summary Add a new data row to the grid.
-     * @desc Reminder: To see the deletion in the grid, you must eventually call:
+     * @desc If data source pipeline in use, to see the new row in the grid, you must eventually call:
      * ```javascript
      * this.grid.behavior.applyAnalytics();
      * this.grid.behaviorChanged();

--- a/version-history.md
+++ b/version-history.md
@@ -1,9 +1,40 @@
+### 1.0.9 - 29 August 2016
+
+* Restored Safari support
+* Added `[halign](http://openfin.github.io/fin-hypergrid/doc/module-defaults.html#halign)` render property.
+* Fixed: Vertical scrollbar is no longer misplaced 200 pixels to the left when grid overflows canvas's container width.
+* Selection model
+    * Added `[multipleSelections](http://openfin.github.io/fin-hypergrid/doc/module-defaults.html#multipleSelections)`, a new grid property that defaults to `false`. Set it to `true` to "opt in" to get the old behavior wherein CTRL-click(-drag) selects additional cell regions. These multiple regions are nearly useless. (The application developer can programmatically inspect the selection model to see all such selections, the user can only COPY the most recently selected region.)
+    * Sample code: Added a new dashboard checkbox _Selection: one cell region at a time_ which (when _one row at a time_ is also checked) causes the cell selection to travel with the row selection. See the code in `fin-row-selection-changed` event listener in demo.js.
+    * Fixed demo: The _Selection: one row at a time_ dashboard checkbox now initializes properly.
+    * Fixed: User can now _un_check individual row selection checkboxes after clicking on the _select all_ checkbox at the top of the row handle column.
+* Tree view
+    * Fixed: Error was previously being thrown when column count was greater than row count.
+    * Improved sorting: Now only sorts on _expandable rows_ (rows with drill-down controls), leaving non-expandable rows (leaf node rows) _stable sorted_ (_i.e.,_ they retain their sort positions from the previous sorter).
+    * Improved default sort: When no column has an explicit sort, the group sorter is automatically applied, _e.g.,_ to the ID column which is usually hidden. UI no longer insists on a visible column sort; this functionality is now completely transparent to the user.
+* Filtering: Filter cell syntax a.k.a. Column Query Language (CQL)
+    * Fixed: Error reported upon encountering operators consisting of consecutive non alpha chars, _e.g.,_ `<=`, `>=`, and `<>` (all of which incidentally have Unicode equivalents in CQL, `≤`, `≥`, and `≠`.)
+    * Added `[opMustBeInMenu](http://openfin.github.io/fin-hypergrid/doc/FilterNode.html#opMustBeInMenu)` column schema option. When `true`, rejects manually entered valid operators not specifically in column's operator menu. Added usage example to demo.js on `last_name` column, which had a custom operator menu.
+    * Fixed CQL syntax support: Certain error conditions were causing premature alerts. Now fails "gracefully."
+    * Fixed SQL syntax support:
+        * SQL parser
+            * Now accepts unquoted numeric operands
+            * Now accepts column name or alias as operand
+        * SQL output
+            * Now outputs column operands (restoring broken functionality)
+* [Find Row API](http://openfin.github.io/fin-hypergrid/doc/rowById.html) plug-in: Find/modify/replace/delete a matching data row object.
+* Added `[dataModel.addRow()](http://openfin.github.io/fin-hypergrid/doc/dataModels.JSON.html#addRow)` method to add a new data row to the grid.
+* Internal change: Replaced use of `KeyboardEvent.keyIdentifier` in favor of `KeyboardEvent.key` because the former will be dropped in _Chromium M53_ due out in September. `KeyboardEvent.key` is also supported in IE 9 and FF 23. It is not however a perfect replacement. See comment under [1.4.0](https://github.com/openfin/fincanvas/blob/master/README.md) for more information.
+* Added grid property 'enableContinuousRepaint' (boolean). This is a _dynamic_ property and can be set or cleared at any time. When set:
+    * Repaint occurs continuously (without have to call `grid.repaint()`).
+    * `grid.getCanvas().currentFPS` is a measure of the number times the grid is being re-rendered each second.
+
 ### 1.0.8 - 8 August 2016
 
 * Wrapped column headers no longer overflow bottom of cell. Overflow is clipped.
 * Clicking to right of last column no longer throws an error.
 * Zooming out (e.g., 80%) now properly clears the grid before repainting.
-* Tree-view add-on improvements:
+* Tree-view plug-in improvements:
     * *Now sorts properly* and maintains a sorted state:
         * On any column sort, applies a _group sorter_ which sorts the column as usual but then automatically stable-sorts each level of group starting with deepest and working up to the top level. (_Stable sorting_ from lowest to highest level grouping is an efficient means of sorting nested data, equivalent to starting with the highest groups and recursing down the tree to each lowest group.)
         * Because raw data order is assumed to be undefined _and_ grouping structure requires that groups be sorted, automatically applies an initial _default sort_ to the "tree" column (name or index specified in `treeColumn` option passed to `TreeView` constructor; defaults to `'name'`). If a default sort column is defined (name or index specified in `defaultSortColumn` option; defaults to the tree column), the initial sort is applied to that column instead.
@@ -17,7 +48,7 @@
         * Make the blank column (now the left-most column) a fixed column (via the grid's `fixedColumnCount` property).
         * Specify some other column for the initial sort (in `option.defaultSortColumn`). This will typically be the column that identifies the group.
         * Demo: [`tree-view-separate-drill-down.html`](http://openfin.github.io/fin-hypergrid/tree-view-separate-drill-down.html)
-* *Grouped column headers* add-on (`add-ons/grouped-columns.js`):
+* *Grouped column headers* plug-in (`add-ons/grouped-columns.js`):
     * Include: `<script src="http://openfin.github.io/fin-hypergrid/build/add-ons/grouped-header.js"></script>`
     * Install: `fin.Hypergrid.groupedHeader.mixInTo(grid)`
     * Usage, for example: `grid.behavior.setHeaders({ lat: 'Coords|Lat.', long: 'Coords|Long.' })`
@@ -29,8 +60,8 @@
     * If the cell value is a function, however, legacy behavior is maintained: This function takes priority over the column function.
 * Upon selecting a new operator from a column filter cell's dropdown, rather than inserting the new operator at the cursor position, the old operator is now _replaced_ by the new one the operator. If the column filter cell contains several expressions (_i.e.,_ concatenated with `and`, `or`, or `nor`), the operator in the expression under the cursor is replaced.
 * Group view
-    * Aggregations and Group View have been added as add-ons and removed from HyperGrid core.
-    * The aggregations add-on has the same behavior as before while the Group View is a view of the original columns, with drill downs in the tree cell for expanding the groups provided.
+    * Aggregations and Group View have been added as plug-ins and removed from HyperGrid core.
+    * The aggregations plug-in has the same behavior as before while the Group View is a view of the original columns, with drill downs in the tree cell for expanding the groups provided.
     * Hypergrid now only loads with the original data source, the filter datasource as defaults, and the sorter data source.
     * Demo 1: [`aggregations.html`](http://openfin.github.io/fin-hypergrid/aggregations-view.html)
     * See Group Demo for example usage: [`group.html`](http://openfin.github.io/fin-hypergrid/group-view.html).


### PR DESCRIPTION
- Added release notes (version-history.html)
- Removed `getCell` from tree-view demos now that we have `halign` render property.
- Added missing semicolon to example.js