### PR TITLE
Revert "BUG/GRID-153"

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -136,8 +136,8 @@ function Hypergrid(div, options) {
         self.checkClipboardCopy(evt);
     });
     this.getCanvas().resize();
+
     this.refreshProperties();
-    this.getCanvas().stopPaintLoop(); // rely on explicit repaint calls
 }
 
 Hypergrid.prototype = {


### PR DESCRIPTION
Reverting... needs more research. turning off paint loop just means that repaints are done immediately and not periodically. not sure why turning it off reduced idle-time CPU usage, possibly simply because requestAnimationFrame was no longer running. in any case it only helped at idle time.