### PR TITLE
Fix column cell properties methods

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -998,7 +998,9 @@ window.onload = function() {
 
         grid.setState(state);
 
-        behavior.setCellProperties(idx.HEIGHT, 16, {
+        // decorate height cell in row "17"
+        var rowOrdinal = 17;
+        behavior.setCellProperties(idx.HEIGHT, behavior.getHeaderRowCount() + (rowOrdinal - 1), {
             font: '10pt Tahoma',
             color: 'lightblue',
             backgroundColor: 'red',

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -730,8 +730,7 @@ var Behavior = Base.extend('Behavior', {
     },
     /**
      * @memberOf Behavior.prototype
-     * @desc First checks to see if something was overridden.
-     * @return {*} The value at x,y for the top left section of the hypergrid.
+     * @return {*} The value at x,y in the hypergrid.
      * @param {number} x - x coordinate
      * @param {number} y - y coordinate
      */

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -179,12 +179,29 @@ Column.prototype = {
     },
 
     getCellProperties: function(y) {
-        y = this.dataModel.getDataIndex(y);
+        var headers = this.behavior.getHeaderRowCount();
+        if (y >= headers) {
+            y = headers + this.dataModel.getDataIndex(y - headers);
+        }
         return this.cellProperties[y] || {};
     },
 
-    setCellProperties: function(y, value) {
-        this.cellProperties[y] = value;
+    setCellProperties: function(y, properties) {
+        var headers = this.behavior.getHeaderRowCount();
+        if (y >= headers) {
+            y = headers + this.dataModel.getDataIndex(y - headers);
+        }
+        this.cellProperties[y] = properties;
+    },
+
+    addCellProperty: function(y, key, value) {
+        var headers = this.behavior.getHeaderRowCount();
+        if (y >= headers) {
+            y = headers + this.dataModel.getDataIndex(y - headers);
+        }
+        var properties = this.cellProperties[y] = this.cellProperties[y] || {};
+        properties[key] = value;
+        return properties;
     },
 
     clearAllCellProperties: function() {


### PR DESCRIPTION
The row coordinate (`y`) was being deindexed but was assumed to be a data row coordinate when in fact it was a grid coordinate. I added code to check if it was in the grid range and subtract the number of header rows before deindexing and added it back afterwards.

This may become a non-issue once we normalize grid coordinates to 0 in GRID-283 which is in this sprint, so let's hold off merging this until we're sure we need it or if 283 is not finished in time.