### PR TITLE
cell props obj now created from column props obj

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -986,11 +986,14 @@ window.onload = function() {
 
         grid.setState(state);
 
-        behavior.setCellProperties(idx.HEIGHT, 16, {
+        // decorate height cell in row "17"
+        var rowOrdinal = 17;
+        behavior.setCellProperties(idx.HEIGHT, behavior.getHeaderRowCount() + (rowOrdinal - 1), {
             font: '10pt Tahoma',
             color: 'lightblue',
             backgroundColor: 'red',
-            halign: 'left'
+            halign: 'left',
+            reapplyCellProperties: true
         });
 
         grid.addProperties({
@@ -1084,6 +1087,7 @@ window.onload = function() {
         });
 
         behavior.setColumnProperties(idx.TRAVEL, {
+            halign: 'right',
             format: 'francs'
         });
 

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -3071,9 +3071,6 @@ Hypergrid.prototype = {
     isColumnSelection: function() {
         return this.resolveProperty('columnSelection') === true;
     },
-    getComputedRow: function(y) {
-        return this.behavior.getComputedRow(y);
-    },
     isColumnAutosizing: function() {
         return this.resolveProperty('columnAutosizing') === true;
     },
@@ -3246,10 +3243,18 @@ Hypergrid.prototype = {
     newRectangle: function(x, y, width, height) {
         return new Rectangle(x, y, width, height);
     },
-    getFormattedValue: function(x, y) {
+
+    /**
+     * @param {number} c - grid cell coordinate
+     * @param {number} r - grid cell coordinate
+     * @returns {*}
+     */
+    getFormattedValue: function(c, r) {
+        var x = this.behavior.getActiveColumn(c),
+            y = r - this.getHeaderRowCount();
         return this.formatValue(
-            this.getColumnProperties(x).format,
-            this.getValue(x, y + this.getHeaderRowCount())
+            this.behavior.getCellProperty(x, y, 'format'),
+            this.getValue(c, r)
         );
     },
 

--- a/src/behaviors/Cell.js
+++ b/src/behaviors/Cell.js
@@ -1,0 +1,108 @@
+/* eslint-env bro wser */
+
+// NOTE: Column.js mixes this module into its prototype
+
+'use strict';
+
+var _ = require('object-iterators');
+
+module.exports = {
+
+    /**
+     * Due to memory constraints, we don't create a cell options properties object for every cell.
+     *
+     * When such a properties object already exists, it:
+     * * was created by a previous call to `setCellProperties` or `setCellProperty`
+     * * has the column properties object as its prototype
+     * * is returned
+     *
+     * When the cell properties object does not yet exist, this method simply returns `undefined`.
+     * Call this method when you need to know if the the cell has its own properties object.
+     * In general, if you are seeking a certain property, you might call {@link Column#getCellProperty} instead (which calls this method).
+     *
+     * @param {number} r - Grid row coordinate.
+     * @returns {undefined|object}
+     * @memberOf Column#
+     */
+    getCellProperties: function(r) {
+        return this.cellProperties[getDataIndex.call(this, r)];
+    },
+
+    /**
+     * @param {number} r - Grid row coordinate.
+     * @param {string} key
+     * @returns {object}
+     * @memberOf Column#
+     */
+    getCellProperty: function(r, key) {
+        return (this.getCellProperties(r) || this.getProperties())[key];
+    },
+
+    /**
+     *
+     * @param {number} r - Grid row coordinate.
+     * @param {object} properties
+     * @param {boolean} [preserve=false]
+     * @returns {*}
+     * @memberOf Column#
+     */
+    setCellProperties: function(r, properties, preserve) {
+        var props = preserve ? getCellPropertiesObject.call(this, r) : newCellPropertiesObject.call(this, r);
+        return _(props).extendOwn(properties);
+    },
+
+    /**
+     * @param {number} r - Grid row coordinate.
+     * @param {string} key
+     * @param value
+     * @returns {object}
+     * @memberOf Column#
+     */
+    setCellProperty: function(r, key, value) {
+        var props = getCellPropertiesObject.call(this, r);
+        props[key] = value;
+        return props;
+    },
+
+    clearAllCellProperties: function() {
+        this.cellProperties = [];
+    }
+};
+
+/**
+ * @summary The data row index at the given grid row index.
+ * @desc If a header row index, returned as is.
+ * @this {Column}
+ * @param {number} r - Grid row coordinate.
+ * @returns {object}
+ * @private
+ */
+function getDataIndex(r) {
+    var headers = this.behavior.getHeaderRowCount();
+    return r < headers ? r : headers + this.dataModel.getDataIndex(r);
+}
+
+/**
+ * @this {Column}
+ * @param {number} r - Grid row coordinate.
+ * @returns {object}
+ * @private
+ */
+function getCellPropertiesObject(r) {
+    return (
+        this.getCellProperties(r) ||
+        newCellPropertiesObject.call(this, r)
+    );
+}
+
+/**
+ * @this {Column}
+ * @param {number} r - Grid row coordinate.
+ * @returns {object}
+ * @private
+ */
+function newCellPropertiesObject(r) {
+    return (
+        this.cellProperties[getDataIndex.call(this, r)] = Object.create(this.getProperties())
+    );
+}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -769,6 +769,13 @@ module.exports = {
      * @instance
      */
     enableContinuousRepaint: false,
+
+    /** @summary Reapply cell properties after `getCell`.
+     * @type {boolean}
+     * @default
+     * @instance
+     */
+    reapplyCellProperties: false
 };
 
 /** @typedef {string} cssColor

--- a/src/lib/deprecated.js
+++ b/src/lib/deprecated.js
@@ -14,10 +14,10 @@ var regexIsMethod = /\)$/;
 
 /**
  * User is warned and new property is returned or new method is called and the result is returned.
- * @param {string} methodName - Deprecated method name with parentheses (required) containing argument list (optional).
+ * @param {string} methodName - Deprecated method name with parentheses (required) containing argument list (optional; see `args` below).
  * @param {string} dotProps - Dot-separated new property name to invoke or method name to call. Method names are indicated by including parentheses with optional argument list. The arguments in each list are drawn from the arguments presented in the `methodName` parameter.
  * @param {string} since - Version in which the name was deprecated.
- * @param {Arguments|Array} [args] - Actual arguments. Only needed when arguments are listed in `methodName`. The order of the arguments must match.
+ * @param {Arguments|Array} [args] - The actual arguments in the order listed in `methodName`. Only needed when arguments need to be forwarded.
  * @param {string} [notes] - Notes to add to message.
  * @returns {*} Return value of new property or method call.
  */
@@ -65,15 +65,17 @@ var deprecated = function(methodName, dotProps, since, args, notes) {
     for (var i = 0, last = chain.length - 1; i <= last; ++i) {
         var link = chain[i],
             name = link.match(/\w+/)[0],
-            actualArgList = regexIsMethod.test(link) ? argList(link) : undefined,
+            isMethod = regexIsMethod.test(link),
+            actualArgList = isMethod ? argList(link) : undefined,
             actualArgs = [];
 
         if (actualArgList) {
             actualArgs = actualArgList.map(mapToFormalArg);
-            link = link.match(/(\w+)/)[1];
             result = result[name].apply(result, actualArgs);
-        } else {
+        } else if (isMethod) {
             result = result[name]();
+        } else {
+            result = result[name];
         }
     }
 

--- a/src/lib/json.js
+++ b/src/lib/json.js
@@ -5,7 +5,7 @@
 var HTTP_STATE_DONE = 4,
     HTTP_STATUS_OK = 200;
 
-module.exports.get = function(url, callback) {
+exports.get = function(url, callback) {
     var httpRequest = new XMLHttpRequest();
 
     httpRequest.open('GET', url, true);


### PR DESCRIPTION
Polishes off the way we build and handle the cell properties object, bringing it into line with the way the other properties objects work:

* The cell properties object is now `Object.create`'d from the column properties objects. This is in keeping with the way the column properties object is created from the grid properties object. Up to now, this cascade had to be done explicitly inline wherever it was needed.
* With this new paradigm, the renderer no longer needs to mix in the cell properties object as a final step after calling `getCell` but before calling the cell renderer's `paint` method. (However, added a new render property `reapplyCellProperties` to get the old behavior, where cell properties override `getCell` settings.)
* Cell properties objects no longer restricted to data cells and can now be used for header cells.
* Isolated all cell properties code into a separate (new) file, behavior/Cell.js. (This is actually just mixed into Columns.prototype by Columns.js, but separating it out should make writing tests for it much cleaner and simpler.)
* This solution does maintain, for efficiency reasons, the paradigm of _avoiding_ creating a cell properties object for every cell (unlike the column properties objects, which are guaranteed to exist for every column). They are creating only when actually needed.
