### PR TITLE
remove config object from renderer instance

### DIFF
--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -285,11 +285,9 @@ Column.prototype = {
      */
     getCellEditorAt: function(y, options) {
         var cellEditor,
-            cellProps = this.getCellProperties(y),
-            columnProps = this.getProperties(),
-            editorName = cellProps.editor || columnProps.editor;
+            editorName = this.getCellProperty(y, 'editor');
 
-        options.format = cellProps.format || columnProps.format;
+        options.format = this.getCellProperty(y, 'format');
 
         cellEditor = this.dataModel.getCellEditorAt(this.index, y, editorName, options);
 

--- a/src/cellRenderers/SliderCell.js
+++ b/src/cellRenderers/SliderCell.js
@@ -25,10 +25,10 @@ var Slider = CellRenderer.extend('Slider', {
             width = config.bounds.width,
             height = config.bounds.height;
         gc.strokeStyle = 'white';
-        var val = this.config.value;
+        var val = config.value;
         var radius = height / 2;
         var offset = width * val;
-        var bgColor = this.config.isSelected ? this.config.backgroundColor : '#333333';
+        var bgColor = config.isSelected ? config.backgroundColor : '#333333';
         var btnGradient = gc.createLinearGradient(x, y, x, y + height);
         btnGradient.addColorStop(0, bgColor);
         btnGradient.addColorStop(1, '#666666');
@@ -46,7 +46,7 @@ var Slider = CellRenderer.extend('Slider', {
         gc.arc(x + Math.max(offset - radius, radius), y + radius, radius, 0, 2 * Math.PI);
         gc.fill();
         gc.closePath();
-        this.config.minWidth = 100;
+        config.minWidth = 100;
     }
 });
 

--- a/src/cellRenderers/SparkBar.js
+++ b/src/cellRenderers/SparkBar.js
@@ -26,15 +26,15 @@ var SparkBar = CellRenderer.extend('SparkBar', {
             height = config.bounds.height;
 
         gc.beginPath();
-        var val = this.config.value;
+        var val = config.value;
         if (!val || !val.length) {
             return;
         }
         var count = val.length;
         var eWidth = width / count;
-        var fgColor = this.config.isSelected ? this.config.foregroundSelectionColor : this.config.color;
-        if (this.config.backgroundColor || this.config.isSelected) {
-            gc.fillStyle = this.config.isSelected ? 'blue' : this.config.backgroundColor;
+        var fgColor = config.isSelected ? config.foregroundSelectionColor : config.color;
+        if (config.backgroundColor || config.isSelected) {
+            gc.fillStyle = config.isSelected ? 'blue' : config.backgroundColor;
             gc.fillRect(x, y, width, height);
         }
         gc.fillStyle = fgColor;
@@ -44,7 +44,7 @@ var SparkBar = CellRenderer.extend('SparkBar', {
             x = x + eWidth;
         }
         gc.closePath();
-        this.config.minWidth = count * 10;
+        config.minWidth = count * 10;
     }
 });
 

--- a/src/cellRenderers/SparkLine.js
+++ b/src/cellRenderers/SparkLine.js
@@ -26,16 +26,16 @@ var SparkLine = CellRenderer.extend('SparkLine', {
             height = config.bounds.height;
 
         gc.beginPath();
-        var val = this.config.value;
+        var val = config.value;
         if (!val || !val.length) {
             return;
         }
         var count = val.length;
         var eWidth = width / count;
 
-        var fgColor = this.config.isSelected ? this.config.foregroundSelectionColor : this.config.color;
-        if (this.config.backgroundColor || this.config.isSelected) {
-            gc.fillStyle = this.config.isSelected ? this.config.backgroundSelectionColor : this.config.backgroundColor;
+        var fgColor = config.isSelected ? config.foregroundSelectionColor : config.color;
+        if (config.backgroundColor || config.isSelected) {
+            gc.fillStyle = config.isSelected ? config.backgroundSelectionColor : config.backgroundColor;
             gc.fillRect(x, y, width, height);
         }
         gc.strokeStyle = fgColor;
@@ -51,7 +51,7 @@ var SparkLine = CellRenderer.extend('SparkLine', {
             gc.arc(x + 5, y + height - barheight, 1, 0, 2 * Math.PI, false);
             x = x + eWidth;
         }
-        this.config.minWidth = count * 10;
+        config.minWidth = count * 10;
         gc.stroke();
         gc.closePath();
     }

--- a/src/cellRenderers/TreeCell.js
+++ b/src/cellRenderers/TreeCell.js
@@ -22,13 +22,13 @@ var TreeCell = CellRenderer.extend('TreeCell', {
             width = config.bounds.width,
             height = config.bounds.height;
 
-        var val = this.config.value.data;
-        var indent = this.config.value.indent;
-        var icon = this.config.value.icon;
+        var val = config.value.data;
+        var indent = config.value.indent;
+        var icon = config.value.icon;
 
         //fill background only if our bgColor is populated or we are a selected cell
-        if (this.config.backgroundColor || this.config.isSelected) {
-            gc.fillStyle = this.config.isSelected ? this.config.backgroundColor : this.config.backgroundColor;
+        if (config.backgroundColor || config.isSelected) {
+            gc.fillStyle = config.isSelected ? config.backgroundColor : config.backgroundColor;
             gc.fillRect(x, y, width, height);
         }
 
@@ -37,12 +37,12 @@ var TreeCell = CellRenderer.extend('TreeCell', {
         }
         var valignOffset = Math.ceil(height / 2);
 
-        gc.fillStyle = this.config.isSelected ? this.config.backgroundColor : this.config.backgroundColor;
+        gc.fillStyle = config.isSelected ? config.backgroundColor : config.backgroundColor;
         gc.fillText(icon + val, x + indent, y + valignOffset);
 
-        var textWidth = this.config.getTextWidth(gc, icon + val);
+        var textWidth = config.getTextWidth(gc, icon + val);
         var minWidth = x + indent + textWidth + 10;
-        this.config.minWidth = minWidth;
+        config.minWidth = minWidth;
     }
 });
 

--- a/src/lib/Renderer.js
+++ b/src/lib/Renderer.js
@@ -1022,7 +1022,6 @@ var Renderer = Base.extend('Renderer', {
             config.dataRow = grid.getRow(r);
             config.columnName = column.name;
             config.calculator = column.calculator;
-
             config.value = grid.getValue(c, r);
         }
 


### PR DESCRIPTION
I removed the config object from the render instances since everywhere it is accessed (paint functions), it is being passed in as a parameter. Everything still seems to work. We can reinstate it if it turns out something obscure needed it.