### PR TITLE
GRID-364: Treeview: Do not filter parent rows

### DIFF
--- a/add-ons/tree-view.js
+++ b/add-ons/tree-view.js
@@ -89,7 +89,7 @@ TreeView.prototype = {
         }
 
         if (options.includeFilter) {
-            dataModel.addPipe({ type: 'DataSourceGlobalFilter' });
+            dataModel.addPipe({ type: 'DataSourceTreeviewFilter' });
         }
 
         if (options.includeSorter) {
@@ -115,9 +115,19 @@ TreeView.prototype = {
             behavior = this.grid.behavior,
             dataModel = behavior.dataModel,
             dataSource = dataModel.sources.treeview,
-            joined = dataSource.setRelation(options),
             state = behavior.getPrivateState(),
+            filterDataSource = this.grid.behavior.dataModel.getGlobalFilterDataSource(),
+            filter = filterDataSource.get();
+
+        // clear filter before setRelation call
+        filterDataSource.set(undefined);
+        dataModel.applyAnalytics();
+
+        var joined = dataSource.setRelation(options),
             columnProps = behavior.getColumn(dataSource.treeColumn.index).getProperties();
+
+        // restore filter after setRelation call
+        filterDataSource.set(filter);
 
         if (joined) {
             // Make the tree column uneditable: Save the current value of the tree column's editable property and set it to false.

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -1254,7 +1254,7 @@ window.onload = function() {
     }
 
     function resetFilter() {
-        grid.setGlobalFilter(Hypergrid.behaviors.Behavior.prototype.getNewFilter.call(grid.behavior));
+        grid.setGlobalFilter(grid.behavior.getNewFilter());
     }
 
     function redIfStartsWithS(dataRow, columnName) {

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -19,8 +19,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     //null object pattern for the source object
     resetSources: function(stopApply) {
         this.sources = {
-            source: new DataSourceOrigin(),
-            globalfilter: new DataSourceOrigin()
+            source: new DataSourceOrigin()
         };
         this.source = this.sources.source;
         this.setPipeline(stopApply);
@@ -51,7 +50,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     getGlobalFilterDataSource: function() {
-        return this.sources.globalfilter;
+        return this.sources.filter;
     },
 
     getData: function() {
@@ -832,7 +831,12 @@ function reselectGridRowsBackedBySelectedDataRows() {
 
 function getDataSourceName(name) {
     name = analytics[name].prototype.$$CLASS_NAME || name;
-    return name.replace(/^Data(Source|Node)/, '').toLowerCase() || 'source';
+    if (/^DataSource\w+Filter$/.test(name)) {
+        name = 'filter';
+    } else {
+        name = name.replace(/^Data(Source|Node)/, '').toLowerCase();
+    }
+    return name;
 }
 
 

--- a/src/dataSources/DataSourceOrigin.js
+++ b/src/dataSources/DataSourceOrigin.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var DataSourceBase = require('./DataSourceBase');
-var headerify = require('hyper-analytics').util.headerify;
+var headerify = require('../Shared.js').analytics.util.headerify;
 
 /**
  * See {@link DataSourceOrigin#initialize} for constructor parameters.
@@ -185,6 +185,15 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
      */
     getHeaders: function() {
         return (
+            /**
+             * @summary The list of header strings.
+             * @desc Congruent to {@link DataSource#fields|fields}.
+             *
+             * Access through {@link DataSource#getHeaders|getHeaders()}.
+             * @name headers
+             * @type {string[]}
+             * @memberOf DataSource#
+             */
             this.headers = this.headers || this.getDefaultHeaders().map(function(each) {
                 return headerify.transform(each);
             })
@@ -236,30 +245,37 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
  */
 function setData(data, fields, calculators) {
 
-    if (!data) {
-        data = [];
-    }
-
     /**
-     * @summary Array of field names.
-     * @desc The order of the names in this array defines the concept of a column index.
-     * @type {string[]}
+     * @summary The array of data row objects.
+     * @desc Access through {@link DataSource#getRow|getRow()}.
+     * @name data
+     * @type {object[]}
+     * @memberOf DataSource#
      */
-    this.fields = fields || computeFieldNames(data[0]);
+    this.data = data || [];
 
     /**
-     * @summary JavaScript functions to calculate the value for computed columns.
-     * @desc The order of this array is defined by {@link DataSourceOrigin#fields}.
-     * This array is typically sparse: Regular columns must not define elements in this array.
+     * @summary The list of field names.
+     * @desc These are all the members of the data row objects visible to Hypergrid.
+     *
+     * Access through {@link DataSource#getFields|getFields()}.
+     * @name fields
+     * @type {string[]}
+     * @memberOf DataSource#
+     */
+    this.fields = fields || computeFieldNames(this.data[0]);
+
+    /**
+     * @summary The list of calculators that implement computed columns.
+     * @desc Congruent to {@link DataSource#fields|fields}.
+     *
+     * Elements representing regular (non-computed) fields should contain `undefined`.
+     * @name calculators
      * @type {function[]}
+     * @memberOf DataSource#
      */
     this.calculators = calculators || Array(this.fields.length);
 
-    /**
-     * @summary Array of uniform objects containing the grid data.
-     * @type {object[]}
-     */
-    this.data = data;
 }
 
 


### PR DESCRIPTION
Paired PR with https://github.com/openfin/hyper-analytics/pull/30

To run this you would have to:
* use the hyper-analytics in https://github.com/openfin/hyper-analytics/pull/30
* uncomment the line you commented-out in behaviors/JSON.js:
```javascript
this.setGlobalFilter(this.getNewFilter());
```