### PR TITLE
GRID-403: Combobox dropdown contents positioning

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -62,6 +62,9 @@ div.hypergrid-input span[title]:hover {
 div.hypergrid-input span[title]:active, div.hypergrid-input span[title].active {
     color: blue;
 }
+div.hypergrid-input > span {
+    margin-top: -1px;
+}
 div.hypergrid-input > span::after {
     content: '\25BE';
     font-size: 20px;
@@ -70,7 +73,7 @@ div.hypergrid-input > div {
     position: absolute;
     left: -1px;
     right: -1px;
-    top: 14px;
+    top: 16px;
     height: 0;
     transition: height .25s;
     visibility: hidden;
@@ -101,13 +104,19 @@ div.hypergrid-input > div span:not([title]) {
 }
 div.hypergrid-input > div select {
     position: absolute;
+    padding-top: 2px;
     border: 0;
     outline: 0;
     border-top: 1px solid #777;
     width: 100%;
+    top: 15px;
     bottom: 0;
-    top:14px;
+    left: 0;
+    right: 0;
     background-color: transparent;
+    font-family: sans-serif;
+    font-weight: bold;
+    font-size: 9px;
 }
 div.hypergrid-input > div select option:hover {
     background-color: #777;

--- a/css/grid.css
+++ b/css/grid.css
@@ -6,7 +6,7 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0 5px;
-    border: 1px solid #777;
+    border: 0; /*border: 1px solid #777;*/
     outline: 0;
 }
 
@@ -15,7 +15,7 @@ div.hypergrid-input {
     display: none;
     outline: 0;
     padding: 0;
-    border: 1px solid #777;
+    border: 0; /*border: 1px solid #777;*/
     box-sizing: border-box;
     background-color: ivory;
     color: black;
@@ -54,6 +54,7 @@ div.hypergrid-input > span {
 div.hypergrid-input span[title] {
     color: lightgrey;
     cursor: pointer;
+    margin-top: -2px;
 }
 div.hypergrid-input span[title]:hover {
     color: grey;

--- a/css/grid.css
+++ b/css/grid.css
@@ -73,7 +73,7 @@ div.hypergrid-input > div {
     position: absolute;
     left: -1px;
     right: -1px;
-    top: 16px;
+    top: 14px;
     height: 0;
     transition: height .25s;
     visibility: hidden;

--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -414,10 +414,10 @@ var CellEditor = Base.extend('CellEditor', {
     setBounds: function(cellBounds) {
         var style = this.el.style;
 
-        style.left = px(cellBounds.x - 1);
-        style.top = px(cellBounds.y - 1);
-        style.width = px(cellBounds.width + 3);
-        style.height = px(cellBounds.height + 3);
+        style.left = px(cellBounds.x + 1);
+        style.top = px(cellBounds.y + 1);
+        style.width = px(cellBounds.width - 1);
+        style.height = px(cellBounds.height - 1);
     },
 
     /**

--- a/src/cellEditors/ComboBox.js
+++ b/src/cellEditors/ComboBox.js
@@ -60,7 +60,7 @@ var ComboBox = Textfield.extend('ComboBox', {
 '    <span title="Click for options"></span>',
 '    <div>',
 '        <div></div>',
-'        <select size="12" lang="{{locale}}"></select>',
+'        <select size="15" lang="{{locale}}"></select>',
 '    </div>',
 '</div>'
     ].join('\n'),
@@ -243,8 +243,10 @@ function slideDown() {
 
     // show the drop-down slide down effect
     this.options.style.visibility = 'visible';
-    var dropDownHeight = this.dropdown.size * 15;
-    this.options.style.height = 2 + 15 + dropDownHeight + 2 + 'px'; // starts the slide down effect
+    var dropDownTopMargin = getFloat(this.dropdown, 'marginTop'),
+        dropDownRows = this.dropdown.size,
+        optionHeight = Math.ceil((this.dropdown.length ? getFloat(this.dropdown[0], 'height') : 13.1875) * 2) / 2 + 1;
+    this.options.style.height = dropDownTopMargin + optionHeight * dropDownRows + 'px'; // starts the slide down effect
 
     // while in drop-down, listen for clicks in text box which means abprt
     this.input.addEventListener('mousedown', this.slideUpBound = slideUp.bind(this));
@@ -264,6 +266,10 @@ function slideUp() {
     this.optionsTransition.begin(function(event) {
         this.style.visibility = 'hidden';
     });
+}
+
+function getFloat(el, style) {
+    return parseFloat(window.getComputedStyle(el)[style]);
 }
 
 

--- a/src/cellRenderers/LastSelection.js
+++ b/src/cellRenderers/LastSelection.js
@@ -31,7 +31,7 @@ var LastSelection = CellRenderer.extend('LastSelection', {
         //     [3, 5, 2, 0],
         //     [4, 5, 1, 0]
         // ];
-        gc.rect(x, y, width, height);
+        gc.rect(x + 1, y + 1, width - 2, height - 2);
         gc.fillStyle = config.selectionRegionOverlayColor;
         gc.fill();
         gc.lineWidth = 1;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -598,7 +598,7 @@ module.exports = {
      * @type {string}
      * @instance
      */
-    selectionRegionOutlineColor: 'black',
+    selectionRegionOutlineColor: 'rgb(69, 69, 69)',
 
     /**
      * @default


### PR DESCRIPTION
This addresses two issues:
* Cleans up cell editor so they look like they are more naturally a part of the grid. Essentially I removed the cell editor borders.
* Repositioned the drop down contents with a `left: 0` ... not sure why this broke.

Let's merge this and I'll push a branch `v1-1-1` of this commit for William's reference. I will also send him the patch file.

Tested in Chrome 53, Chrome 40, Firefox 48. Combobox always had problems in Safari. I just tried it in Safari 10.0 and still has issues. We should fix this at some point but I wouldn't hold up this merge for Safari.