### PR TITLE
container creation, naming, css class

### DIFF
--- a/css/grid.css
+++ b/css/grid.css
@@ -1,3 +1,7 @@
+.hypergrid-container {
+    position: relative;
+    height: 500px;
+}
 .hypergrid-textfield {
     position: absolute;
     font-size: 12px;


### PR DESCRIPTION
Removed default container size/position styles from code and put in new css class `hypergrid-container`. There was a problem with instantiating multiple grids on the same page when depending on the container creation code. That code first looked for a container id="hypergrid" and if found, use it; if not found create it. So first time it created it; subsequently it found it, so kept appending additional grids inside it. I fixed this by
1. requring the found container to be empty in order to use it. 
2. Moved the naming to the initContainer function, but instead of always naming it hypergrid, I named it hypergrid, hypergrid1, hypergrid2, hypergrid3, etc.