### PR TITLE
Bug/scroll on focus

### DIFF
--- a/src/cellEditors/CellEditor.js
+++ b/src/cellEditors/CellEditor.js
@@ -393,7 +393,9 @@ var CellEditor = Base.extend('CellEditor', {
 
         el.style.left = el.style.top = 0; // work-around: move to upper left
 
+        var x = window.scrollX, y = window.scrollY;
         this.input.focus();
+        window.scrollTo(x, y);
         this.selectAll();
 
         el.style.left = leftWas;


### PR DESCRIPTION
I have experienced an issue whereby the screen can scroll after an editor shown.  I did some debugging and found the issue occurs because of the focus change that occurs on the editor element.  Further this was found as a resolution:  http://stackoverflow.com/questions/4898203/jquery-focus-without-scroll

I added that change to prevent window from scrolling after a cell editor has taken focus.  I tested the fix in chrome and firefox but was unable to test in safari and ie 10+ as I do not have access to these browsers.