### PR TITLE
Moved behavior.tableState object to grid.properties

### DIFF
--- a/add-ons/aggregations-view.js
+++ b/add-ons/aggregations-view.js
@@ -99,7 +99,7 @@ AggregationsView.prototype.setAggregateGroups = function(aggregations, groups) {
 
     var dataSource = dataModel.findDataSourceByType('aggregator'),
         columnProps = behavior.getColumnProperties(dataSource.treeColumnIndex),
-        state = behavior.getPrivateState();
+        state = grid.properties;
 
     if (aggregated) {
         dataSource.setAggregateGroups(aggregations, groups);

--- a/add-ons/group-view.js
+++ b/add-ons/group-view.js
@@ -145,7 +145,7 @@ GroupView.prototype = {
 
         var dataSource = dataModel.findDataSourceByType('groupviewer'),
             columnProps = behavior.getColumnProperties(dataSource.treeColumnIndex),
-            state = behavior.getPrivateState();
+            state = grid.properties;
 
         dataSource.setGroupBys(groups);
 

--- a/add-ons/tree-view.js
+++ b/add-ons/tree-view.js
@@ -84,7 +84,7 @@ TreeView.prototype.setRelation = function(join) {
     var dataSource = dataModel.findDataSourceByType('treeviewer'),
         joined = dataSource.setRelation(join && this.options),
         columnProps = behavior.getColumnProperties(dataSource.treeColumn.index),
-        state = behavior.getPrivateState();
+        state = grid.properties;
 
     if (joined) {
         // Make the tree column uneditable: Save the current value of the tree column's editable property and set it to false.

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -843,8 +843,8 @@ window.onload = function() {
         var rows = detail.rows,
             selections = detail.selections;
         if (
-            grid.resolveProperty('singleRowSelectionMode') && // let's only attempt this when in this mode
-            !grid.resolveProperty('multipleSelections') && // and only when in single selection mode
+            grid.properties.singleRowSelectionMode && // let's only attempt this when in this mode
+            !grid.properties.multipleSelections && // and only when in single selection mode
             rows.length && // user just selected a row (must be single row due to mode we're in)
             selections.length  // there was a cell region selected (must be the only one)
         ) {
@@ -1174,7 +1174,7 @@ window.onload = function() {
                 case 'radio':
                     input.checked = 'checked' in ctrl
                         ? ctrl.checked
-                        : grid.resolveProperty(ctrl.name);
+                        : resolveGridProperty(ctrl.name);
                     referenceElement = null; // label goes before input
                     break;
             }
@@ -1197,6 +1197,13 @@ window.onload = function() {
         ctrlGroups.appendChild(container);
     }
 
+    function resolveGridProperty(key) {
+        var keys = key.split('.');
+        var prop = grid.properties;
+        while (keys.length) { prop = prop[keys.shift()]; }
+        return prop;
+    }
+
     document.getElementById('tab-dashboard').addEventListener('click', function(event) {
         if (dashboard.style.display === 'none') {
             dashboard.style.display = 'block';
@@ -1213,7 +1220,7 @@ window.onload = function() {
     var fpsTimer, secs, frames;
     document.getElementById('tab-fps').addEventListener('click', function(event) {
         var el = this, st = el.style;
-        if ((grid.getProperties().enableContinuousRepaint ^= true)) {
+        if ((grid.properties.enableContinuousRepaint ^= true)) {
             st.backgroundColor = '#666';
             st.textAlign = 'left';
             secs = frames = 0;

--- a/demo/js/tree-view-separate-drill-down.js
+++ b/demo/js/tree-view-separate-drill-down.js
@@ -53,11 +53,11 @@ window.onload = function() {
             dd.header = dd.column.header;
             dd.column.header = '';
 
-            dd.unsortable = dd.column.getProperties().unsortable;
-            dd.column.getProperties().unsortable = true;
+            dd.unsortable = dd.column.properties.unsortable;
+            dd.column.properties.unsortable = true;
         } else {
             dd.column.header = dd.header;
-            dd.column.getProperties().unsortable = dd.unsortable;
+            dd.column.properties.unsortable = dd.unsortable;
         }
         button.disabled = !this.checked;
     };

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -372,7 +372,7 @@ Hypergrid.prototype = {
     },
 
     getProperties: function() {
-        return this.getPrivateState();
+        return this.deprecated('getProperties()', 'properties', '1.2.0');
     },
 
     _getProperties: function() {
@@ -424,11 +424,11 @@ Hypergrid.prototype = {
     },
 
     isRowResizeable: function() {
-        return this.resolveProperty('rowResize');
+        return this.properties.rowResize;
     },
 
     isCheckboxOnlyRowSelections: function() {
-        return this.resolveProperty('checkboxOnlyRowSelections');
+        return this.properties.checkboxOnlyRowSelections;
     },
 
     /**
@@ -504,7 +504,7 @@ Hypergrid.prototype = {
      * @param {object} properties - An object of various key value pairs.
      */
     refreshProperties: function() {
-        var state = this.getProperties();
+        var state = this.properties;
         this.selectionModel.multipleSelections = state.multipleSelections;
 
         // this.canvas = this.shadowRoot.querySelector('fin-canvas');
@@ -524,7 +524,7 @@ Hypergrid.prototype = {
      * @param {object} moreProperties - A simple properties hash.
      */
     addProperties: function(moreProperties) {
-        var properties = this.getProperties();
+        var properties = this.properties;
         addDeepProperties(properties, moreProperties);
         this.refreshProperties();
     },
@@ -535,7 +535,7 @@ Hypergrid.prototype = {
      * @see [Memento pattern](http://en.wikipedia.org/wiki/Memento_pattern)
      */
     getPrivateState: function() {
-        return this.behavior.getPrivateState();
+        return this.deprecate('getPrivateState()', 'properties', '1.2.0');
     },
 
     /**
@@ -936,14 +936,13 @@ Hypergrid.prototype = {
      * @param {string} key - A look-and-feel key.
      */
     resolveProperty: function(key) {
-        var keys = key.split('.');
-        var prop = this.getProperties();
-        while (keys.length) { prop = prop[keys.shift()]; }
-        return prop;
+        // todo: when we remove this mehtod, also remove forwards from Behavior.js and Renderer.js
+        console.warn('resolveProperty(key) deprecated as of v1.2.0 in favor of grid.properties[key] and will be removed in a future version.');
+        return this.properties[key];
     },
 
     repaint: function() {
-        var now = this.resolveProperty('repaintImmediately');
+        var now = this.properties.repaintImmediately;
         var canvas = this.getCanvas();
         if (canvas) {
             if (now === true) {
@@ -967,7 +966,7 @@ Hypergrid.prototype = {
      * @returns {boolean} In HiDPI mode (has an attribute as such).
      */
     useHiDPI: function() {
-        return this.resolveProperty('useHiDPI') !== false;
+        return this.properties.useHiDPI !== false;
     },
 
     /**
@@ -1049,7 +1048,7 @@ Hypergrid.prototype = {
         };
 
         this.addEventListener('fin-canvas-mousemove', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             var mouse = e.detail.mouse;
@@ -1059,7 +1058,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-mousedown', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             //self.stopEditing();
@@ -1074,7 +1073,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-click', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             //self.stopEditing();
@@ -1087,7 +1086,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-mouseup', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             self.dragging = false;
@@ -1110,7 +1109,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-dblclick', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             var mouse = e.detail.mouse;
@@ -1121,7 +1120,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-drag', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             self.dragging = true;
@@ -1132,7 +1131,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-keydown', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             self.fireSyntheticKeydownEvent(e);
@@ -1140,7 +1139,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-keyup', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             self.fireSyntheticKeyupEvent(e);
@@ -1155,7 +1154,7 @@ Hypergrid.prototype = {
         });
 
         this.addEventListener('fin-canvas-mouseout', function(e) {
-            if (self.resolveProperty('readOnly')) {
+            if (self.properties.readOnly) {
                 return;
             }
             var mouse = e.detail.mouse;
@@ -1432,7 +1431,7 @@ Hypergrid.prototype = {
 
         if (editPoint.x >= 0 && editPoint.y >= 0) {
             var column = this.behavior.getActiveColumn(editPoint.x),
-                editable = column && column.getProperties().editable;
+                editable = column && column.properties.editable;
 
             if (editable || this.isFilterRow(editPoint.y)) {
                 this.setMouseDown(editPoint);
@@ -2275,8 +2274,8 @@ Hypergrid.prototype = {
         this.sbHScroller = horzBar;
         this.sbVScroller = vertBar;
 
-        var hPrefix = this.resolveProperty('hScrollbarClassPrefix');
-        var vPrefix = this.resolveProperty('vScrollbarClassPrefix');
+        var hPrefix = this.properties.hScrollbarClassPrefix;
+        var vPrefix = this.properties.vScrollbarClassPrefix;
 
         if (hPrefix && hPrefix !== '') {
             this.sbHScroller.classPrefix = hPrefix;
@@ -2936,7 +2935,7 @@ Hypergrid.prototype = {
     },
 
     isHeaderWrapping: function() {
-        return this.resolveProperty('headerTextWrapping');
+        return this.properties.headerTextWrapping;
     },
 
     _getBoundsOfCell: function(x, y) {
@@ -3159,16 +3158,16 @@ Hypergrid.prototype = {
     },
 
     isShowRowNumbers: function() {
-        return this.resolveProperty('showRowNumbers');
+        return this.properties.showRowNumbers;
     },
     isEditable: function() {
-        return this.resolveProperty('editable') === true;
+        return this.properties.editable === true;
     },
     isShowFilterRow: function() {
-        return this.resolveProperty('showFilterRow');
+        return this.properties.showFilterRow;
     },
     isShowHeaderRow: function() {
-        return this.resolveProperty('showHeaderRow');
+        return this.properties.showHeaderRow;
     },
     getHeaderRowCount: function() {
         return this.behavior.getHeaderRowCount();
@@ -3186,8 +3185,8 @@ Hypergrid.prototype = {
         return this.hasHierarchyColumn() && x === 0;
     },
     checkScrollbarVisibility: function() {
-        // var hoverClassOver = this.resolveProperty('scrollbarHoverOver');
-        // var hoverClassOff = this.resolveProperty('scrollbarHoverOff');
+        // var hoverClassOver = this.properties.scrollbarHoverOver;
+        // var hoverClassOff = this.properties.scrollbarHoverOff;
 
         // if (hoverClassOff === 'visible') {
         //     this.sbHScroller.classList.remove(hoverClassOver);
@@ -3219,7 +3218,7 @@ Hypergrid.prototype = {
         }
     },
     isRowNumberAutosizing: function() {
-        return this.resolveProperty('rowNumberAutosizing');
+        return this.properties.rowNumberAutosizing;
     },
     isRowSelected: function(r) {
         return this.selectionModel.isRowSelected(r);
@@ -3234,16 +3233,16 @@ Hypergrid.prototype = {
         return this.behavior.getRow(y);
     },
     isCellSelection: function() {
-        return this.resolveProperty('cellSelection') === true;
+        return this.properties.cellSelection === true;
     },
     isRowSelection: function() {
-        return this.resolveProperty('rowSelection') === true;
+        return this.properties.rowSelection === true;
     },
     isColumnSelection: function() {
-        return this.resolveProperty('columnSelection') === true;
+        return this.properties.columnSelection === true;
     },
     isColumnAutosizing: function() {
-        return this.resolveProperty('columnAutosizing') === true;
+        return this.properties.columnAutosizing === true;
     },
 
     selectRowsFromCells: function() {
@@ -3296,7 +3295,7 @@ Hypergrid.prototype = {
         this.repaint();
     },
     isSingleRowSelectionMode: function() {
-        return this.resolveProperty('singleRowSelectionMode');
+        return this.properties.singleRowSelectionMode;
     },
     newPoint: function(x, y) {
         return new Point(x, y);

--- a/src/behaviors/cellProperties.js
+++ b/src/behaviors/cellProperties.js
@@ -37,7 +37,7 @@ var cell = {
      * @memberOf Column#
      */
     getCellProperty: function(r, key) {
-        return (this.getCellProperties(r) || this.getProperties())[key];
+        return (this.getCellProperties(r) || this.properties)[key];
     },
 
     /**
@@ -105,7 +105,7 @@ function getCellPropertiesObject(r) {
  */
 function newCellPropertiesObject(r) {
     return (
-        this.cellProperties[getDataIndex.call(this, r)] = Object.create(this.getProperties())
+        this.cellProperties[getDataIndex.call(this, r)] = Object.create(this.properties)
     );
 }
 

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -52,7 +52,7 @@ var FIELD = 'columnProperties.field is deprecated as of v1.1.0 in favor of colum
  */
 function createColumnProperties() {
     var column = this,
-        tableState = column.behavior.getPrivateState(),
+        tableState = column.behavior.grid.properties,
         properties;
 
     properties = Object.create(tableState, {

--- a/src/cellEditors/FilterBox.js
+++ b/src/cellEditors/FilterBox.js
@@ -155,7 +155,7 @@ var FilterBox = ComboBox.extend('FilterBox', {
         if (e) {
             prototype.keyup.call(this, e);
 
-            if (this.grid.resolveProperty('filteringMode') === 'immediate') {
+            if (this.grid.properties.filteringMode === 'immediate') {
                 this.saveEditorValue(this.getEditorValue());
                 this.moveEditor();
             }

--- a/src/dataModels/DataModel.js
+++ b/src/dataModels/DataModel.js
@@ -16,13 +16,7 @@ var DataModel = Base.extend('DataModel', {
     },
 
     getPrivateState: function() {
-        var state;
-        try {
-            state = this.grid.getPrivateState();
-        } catch (err) {
-            state = {}; // in case no beahvior yet
-        }
-        return state;
+        return this.deprecate('getPrivateState()', 'grid.properties', '1.2.0');
     },
 
     /**

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -286,7 +286,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @returns {number}
      */
     getColumnCount: function() {
-        var showTree = this.grid.resolveProperty('showTreeColumn') === true;
+        var showTree = this.grid.properties.showTreeColumn === true;
         var offset = (this.isDrillDown() && !showTree) ? -1 : 0;
         return this.dataSource.getColumnCount() + offset;
     },
@@ -608,7 +608,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @returns {boolean}
      */
     hasHierarchyColumn: function() {
-        var showTree = this.grid.resolveProperty('showTreeColumn') === true;
+        var showTree = this.grid.properties.showTreeColumn === true;
         return this.isDrillDown() && showTree;
     },
 
@@ -617,7 +617,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @desc returns the columns that currently sorted and their intended direction of the sort
      */
     getSortedColumnIndexes: function() {
-        var state = this.getPrivateState();
+        var state = this.grid.properties;
         state.sorts = state.sorts || [];
         return state.sorts;
     },

--- a/src/dialogs/ColumnPicker.js
+++ b/src/dialogs/ColumnPicker.js
@@ -58,7 +58,7 @@ var ColumnPicker = Dialog.extend('ColumnPicker', {
                 models: behavior.getActiveColumns()
             };
 
-            this.sortOnHiddenColumns = this.wasSortOnHiddenColumns = grid.resolveProperty('sortOnHiddenColumns');
+            this.sortOnHiddenColumns = this.wasSortOnHiddenColumns = grid.properties.sortOnHiddenColumns;
 
             var columnPicker = new ListDragon([
                 this.inactiveColumns,
@@ -79,7 +79,7 @@ var ColumnPicker = Dialog.extend('ColumnPicker', {
                 grid.fireSyntheticOnColumnsChangedEvent();
             });
 
-            this.sortOnHiddenColumns = this.grid.resolveProperty('sortOnHiddenColumns');
+            this.sortOnHiddenColumns = this.grid.properties.sortOnHiddenColumns;
         } else {
             var div = document.createElement('div');
             div.style.textAlign = 'center';

--- a/src/features/CellEditing.js
+++ b/src/features/CellEditing.js
@@ -16,7 +16,7 @@ var CellEditing = Feature.extend('CellEditing', {
      * @param {Object} event - the event details
      */
     handleDoubleClick: function(grid, event) {
-        var isDoubleClickEditorActivation = grid.resolveProperty('editOnDoubleClick');
+        var isDoubleClickEditorActivation = grid.properties.editOnDoubleClick;
         if (this.checkActivateEditor(grid, event, isDoubleClickEditorActivation)) {
             grid.onEditorActivate(event);
         } else if (this.next) {
@@ -25,7 +25,7 @@ var CellEditing = Feature.extend('CellEditing', {
     },
 
     handleClick: function(grid, event) {
-        var isDoubleClickEditorActivation = grid.resolveProperty('editOnDoubleClick');
+        var isDoubleClickEditorActivation = grid.properties.editOnDoubleClick;
         if (this.checkActivateEditor(grid, event, !isDoubleClickEditorActivation)) {
             grid.onEditorActivate(event);
         } else if (this.next) {
@@ -54,7 +54,7 @@ var CellEditing = Feature.extend('CellEditing', {
         var char, isVisibleChar, isDeleteChar, currentCell, editor;
 
         if (
-            grid.resolveProperty('editOnKeydown') &&
+            grid.properties.editOnKeydown &&
             !grid.cellEditor &&
             (
                 (char = event.detail.char) === 'F2' ||

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -196,7 +196,7 @@ var CellSelection = Feature.extend('CellSelection', {
      * @param {Object} mouse - the event details
      */
     checkDragScroll: function(grid, mouse) {
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             return;
         }
         var b = grid.getDataBounds();
@@ -467,7 +467,7 @@ var CellSelection = Feature.extend('CellSelection', {
         var maxViewableColumns = grid.getVisibleColumns() - 1;
         var maxViewableRows = grid.getVisibleRows() - 1;
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxColumns = Math.min(maxColumns, maxViewableColumns);
             maxRows = Math.min(maxRows, maxViewableRows);
         }
@@ -515,7 +515,7 @@ var CellSelection = Feature.extend('CellSelection', {
         var minRows = grid.getHeaderRowCount();
         var minCols = grid.getHeaderColumnCount();
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxColumns = Math.min(maxColumns, maxViewableColumns);
             maxRows = Math.min(maxRows, maxViewableRows);
         }

--- a/src/features/ColumnMoving.js
+++ b/src/features/ColumnMoving.js
@@ -382,8 +382,8 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.boxShadow = '0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)';
         style.width = columnWidth + 'px'; //Math.round(columnWidth / hdpiRatio) + 'px';
         style.height = colHeight + 'px'; //Math.round(colHeight / hdpiRatio) + 'px';
-        style.borderTop = '1px solid ' + renderer.resolveProperty('lineColor');
-        style.backgroundColor = renderer.resolveProperty('backgroundColor');
+        style.borderTop = '1px solid ' + grid.properties.lineColor;
+        style.backgroundColor = grid.properties.backgroundColor;
 
         var startX = columnEdges[columnIndex - scrollLeft];
         startX = startX * hdpiRatio;
@@ -464,8 +464,8 @@ var ColumnMoving = Feature.extend('ColumnMoving', {
         style.opacity = 0.85;
         style.boxShadow = '0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22)';
         //style.zIndex = 100;
-        style.borderTop = '1px solid ' + renderer.resolveProperty('lineColor');
-        style.backgroundColor = grid.renderer.resolveProperty('backgroundColor');
+        style.borderTop = '1px solid ' + grid.properties.lineColor;
+        style.backgroundColor = grid.properties.backgroundColor;
 
         d.setAttribute('width', Math.round(columnWidth * hdpiRatio) + 'px');
         d.setAttribute('height', Math.round(colHeight * hdpiRatio) + 'px');

--- a/src/features/ColumnPicker.js
+++ b/src/features/ColumnPicker.js
@@ -19,7 +19,7 @@ var ColumnPicker = Feature.extend('ColumnPicker', {
      */
     handleKeyUp: function(grid, event) {
         var key = event.detail.char.toLowerCase();
-        var keys = grid.resolveProperty('editorActivationKeys');
+        var keys = grid.properties.editorActivationKeys;
         if (keys.indexOf(key) > -1) {
            grid.toggleDialog('ColumnPicker');
         }

--- a/src/features/ColumnSelection.js
+++ b/src/features/ColumnSelection.js
@@ -121,7 +121,7 @@ var ColumnSelection = Feature.extend('ColumnSelection', {
                 var keys = primEvent.detail.keys;
                 this.dragging = true;
                 this.extendSelection(grid, dCell, keys);
-            }.bind(this), grid.resolveProperty('doubleClickDelay') + RACE_TIME);
+            }.bind(this), grid.properties.doubleClickDelay + RACE_TIME);
         }
     },
 
@@ -222,7 +222,7 @@ var ColumnSelection = Feature.extend('ColumnSelection', {
      * @param {Object} mouse - the event details
      */
     checkDragScroll: function(grid, mouse) {
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             return;
         }
         var b = grid.getDataBounds();
@@ -481,7 +481,7 @@ var ColumnSelection = Feature.extend('ColumnSelection', {
 
         var maxViewableColumns = grid.getVisibleColumns() - 1;
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxColumns = Math.min(maxColumns, maxViewableColumns);
         }
 
@@ -519,7 +519,7 @@ var ColumnSelection = Feature.extend('ColumnSelection', {
 
         var maxViewableColumns = grid.getVisibleColumnsCount() - 1;
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxColumns = Math.min(maxColumns, maxViewableColumns);
         }
 

--- a/src/features/RowSelection.js
+++ b/src/features/RowSelection.js
@@ -194,7 +194,7 @@ var RowSelection = Feature.extend('RowSelection', {
      * @param {Object} mouse - the event details
      */
     checkDragScroll: function(grid, mouse) {
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             return;
         }
         var b = grid.getDataBounds();
@@ -434,7 +434,7 @@ var RowSelection = Feature.extend('RowSelection', {
 
         var maxViewableRows = grid.getVisibleRows() - 1;
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxRows = Math.min(maxRows, maxViewableRows);
         }
 
@@ -473,7 +473,7 @@ var RowSelection = Feature.extend('RowSelection', {
 
         var maxViewableRows = grid.getVisibleRowsCount() - 1;
 
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             maxRows = Math.min(maxRows, maxViewableRows);
         }
 

--- a/src/features/ThumbwheelScrolling.js
+++ b/src/features/ThumbwheelScrolling.js
@@ -14,7 +14,7 @@ var ThumbwheelScrolling = Feature.extend('ThumbwheelScrolling', {
      * @param {Object} event - the event details
      */
     handleWheelMoved: function(grid, e) {
-        if (!grid.resolveProperty('scrollingEnabled')) {
+        if (!grid.properties.scrollingEnabled) {
             return;
         }
 

--- a/src/lib/Renderer.js
+++ b/src/lib/Renderer.js
@@ -172,11 +172,12 @@ var Renderer = Base.extend('Renderer', {
     },
 
     /**
+     * Keep in place! Used by fin-canvas.
      * @memberOf Renderer.prototype
      * @returns {Object} a property value at a key, delegates to the grid
      */
     resolveProperty: function(key) {
-        return this.grid.resolveProperty(key);
+        return this.grid.properties[key];
     },
 
     /**
@@ -188,7 +189,7 @@ var Renderer = Base.extend('Renderer', {
     paint: function(gc) {
         if (this.grid) {
             if (!this.hasData()) {
-                var message = this.grid.resolveProperty('noDataMessage');
+                var message = this.grid.properties.noDataMessage;
                 gc.font = '20px Arial';
                 gc.fillText(message, 20, 30);
             } else {
@@ -588,8 +589,8 @@ var Renderer = Base.extend('Renderer', {
                 width: width,
                 height: height
             },
-            selectionRegionOverlayColor: this.grid.resolveProperty('selectionRegionOverlayColor'),
-            selectionRegionOutlineColor: this.grid.resolveProperty('selectionRegionOutlineColor')
+            selectionRegionOverlayColor: this.grid.properties.selectionRegionOverlayColor,
+            selectionRegionOutlineColor: this.grid.properties.selectionRegionOutlineColor
         };
         this.grid.cellRenderers.get('lastselection').paint(gc, config);
     },
@@ -627,7 +628,7 @@ var Renderer = Base.extend('Renderer', {
         var targetCTX = override.ctx;
         var imgData = gc.getImageData(startX, 0, Math.round(width * hdpiRatio), Math.round(height * hdpiRatio));
         targetCTX.putImageData(imgData, 0, 0);
-        gc.fillStyle = this.resolveProperty('backgroundColor2');
+        gc.fillStyle = this.grid.properties.backgroundColor2;
         gc.fillRect(Math.round(startX / hdpiRatio), 0, width, height);
     },
 
@@ -884,10 +885,11 @@ var Renderer = Base.extend('Renderer', {
         var rowHeights = this.rowEdges;
         var viewHeight;
         var viewWidth = colWidths[colWidths.length - 1];
-        var drawThemH = this.resolveProperty('gridLinesH');
-        var drawThemVOverflow = this.resolveProperty('gridLinesVOverflow');
-        var drawThemV = this.resolveProperty('gridLinesV');
-        var lineColor = this.resolveProperty('lineColor');
+        var props = this.grid.properties;
+        var drawThemH = props.gridLinesH;
+        var drawThemVOverflow = props.gridLinesVOverflow;
+        var drawThemV = props.gridLinesV;
+        var lineColor = props.lineColor;
         if (drawThemVOverflow){
             viewHeight = this.getBounds().height;
         } else {
@@ -924,7 +926,7 @@ var Renderer = Base.extend('Renderer', {
         gc.closePath();
 
         gc.strokeStyle = lineColor;
-        gc.lineWidth = this.resolveProperty('lineWidth');
+        gc.lineWidth = props.lineWidth;
         gc.stroke();
     },
 
@@ -951,7 +953,7 @@ var Renderer = Base.extend('Renderer', {
             behavior = grid.behavior,
             column = behavior.getActiveColumn(c),
             cellProperties = column && column.getCellProperties(r),
-            baseProperties = cellProperties || column && column.getProperties();
+            baseProperties = cellProperties || column && column.properties;
 
         if (!baseProperties) {
             return;


### PR DESCRIPTION
move call to getDefaultState() to setState() and reset()

deprecate getPrivateState() in favor of grid.properties
change all refs to getPrivateState() to grid.properties

change all refs to tableState to grid.properties

deprecate resolveProperty(xxx) in favor of grid.properties[xxx]
change all refs to resolveProperty('xxx') to grid.properties.xxx

deprecate grid.getProperties in favor of .properties
change all grid.getProperties() to grid.properties

deprecated column.getProperties in favor of new column.properties getter
change all column.getProperties to column.properties

deprecated column.setProperties in favor of new column.properties setter AND column.addProperties