### PR TITLE
v1.2.2 patch: getCell config should not be sticky

### DIFF
--- a/demo/performance.html
+++ b/demo/performance.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
+    <style>.hypergrid-container { width:1000px; height:1000px }</style>
+</head>
+<body>
+    <script src="build/fin-hypergrid.js"></script>
+
+    <script>
+        var data = [
+            { s: 'APPL', n: 'Apple', c: 93.13 },
+            { s: 'MSFT', n: 'Microsoft', c: 51.91 },
+            { s: 'TSLA', n: 'Tesla', c: 196.40 },
+            { s: 'IBM', n: 'IBM', c: 155.35 }
+        ];
+        var grid = new fin.Hypergrid();
+        data.forEach(function(dr) { for (var i=1; i<=6; ++i) { ['s','n','c'].find(function(key) { dr[key+i] = dr[key] }); } });
+        for(var i=7; --i; ) { data = data.concat(data); }
+        grid.setData(data);
+        grid.addProperties({
+            enableContinuousRepaint: true
+        });
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fin-hypergrid",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Canvas-based high-performance spreadsheet",
   "repository": {
     "type": "git",

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -289,14 +289,10 @@ var Behavior = Base.extend('Behavior', {
      * @return {object} Newly created default empty tablestate.
      */
     getDefaultState: function() {
-        var tableProperties = this.grid._getProperties();
-        var state = Object.create(tableProperties);
-
-        _(state).extendOwn({
-            columnProperties: []
-        });
-
-        return state;
+        return Object.create(
+            this.grid._getProperties(),
+            { columnProperties: { value: [] } }
+        );
     },
 
     /**

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -266,11 +266,11 @@ Column.prototype = {
     },
 
     get properties() {
-        var tableState = this.behavior.grid.properties,
-            result = tableState.columnProperties[this.index];
+        var columnProperties = this.behavior.grid.properties.columnProperties,
+            result = columnProperties[this.index];
 
         if (!result) {
-            result = tableState.columnProperties[this.index] = this.createColumnProperties();
+            result = columnProperties[this.index] = this.createColumnProperties();
         }
 
         return result;

--- a/src/dataSources/DataSourceOrigin.js
+++ b/src/dataSources/DataSourceOrigin.js
@@ -334,7 +334,7 @@ function computeFieldNames(object) {
     if (!object) {
         return [];
     }
-    return Object.getOwnPropertyNames(object || []).filter(function(e) {
+    return Object.keys(object || []).filter(function(e) {
         return e.substr(0, 2) !== '__';
     });
 }

--- a/src/lib/SelectionModel.js
+++ b/src/lib/SelectionModel.js
@@ -18,7 +18,7 @@ function SelectionModel(grid) {
      * @summary Can select multiple cell regions.
      * @memberOf SelectionModel.prototype
      */
-    this.multipleSelections = grid[grid.behavior ? 'getProperties' : '_getProperties']().multipleSelections;
+    this.multipleSelections = (grid.behavior ? grid.properties : grid._getProperties()).multipleSelections;
 
     /**
      * @name selections


### PR DESCRIPTION
@Dwaynekj One of the optimizations I put in 1.2.1 makes `getCell` changes to `config` look-and-feel props sticky till the bottom of each column. This was unintended. This patch restores it and I believe we should push this soon (like today). Unfortunately, we loose the ~1 FPS that was gained by this change.