### PR TITLE
draw rect + v-lines per column + h-lines after

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -459,7 +459,7 @@ window.onload = function() {
                         case 5:
                             config.backgroundColor = '#e8ffe8';
                             config.font = 'italic x-small verdana';
-                            if (config.color !== redIfStartsWithS) {
+                            if (x !== idx.LAST_NAME) {
                                 config.color = '#070';
                             }
                             break;
@@ -475,6 +475,8 @@ window.onload = function() {
 
                 switch (x) {
                     case idx.LAST_NAME:
+                        config.color = config.value != null && (config.value + '')[0] === 'S' ? 'red' : '#191919';
+                        // eslint-disable-line no-fallthrough
                     case idx.FIRST_NAME:
                     case idx.BIRTH_STATE:
                     case idx.RESIDENCE_STATE:
@@ -1054,7 +1056,6 @@ window.onload = function() {
         //                    });
 
         behavior.setColumnProperties(idx.LAST_NAME, {
-            color: redIfStartsWithS,
             columnHeaderBackgroundColor: '#142B6F', //dark blue
             columnHeaderColor: 'white'
         });
@@ -1420,11 +1421,5 @@ window.onload = function() {
 
     function setGlobalSorter() {
         grid.sorter = grid.plugins.hypersorter;
-    }
-
-    function redIfStartsWithS(dataRow, columnName) {
-        //does the data start with an 'S'?
-        var value = dataRow[columnName];
-        return value != null && (value + '')[0] === 'S' ? 'red' : '#191919';
     }
 };

--- a/demo/performance.html
+++ b/demo/performance.html
@@ -19,6 +19,7 @@
         for(var i=7; --i; ) { data = data.concat(data); }
         grid.setData(data);
         grid.addProperties({
+            foregroundSelectionFont: '13px Tahoma, Geneva, sans-serif',
             enableContinuousRepaint: true
         });
     </script>

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1064,7 +1064,6 @@ var Hypergrid = Base.extend('Hypergrid', {
 
         this.canvas = new Canvas(divCanvas, this.renderer);
         this.canvas.canvas.classList.add('hypergrid');
-        this.canvas.canvas.style.backgroundColor = this.properties.lineColor;
         this.canvas.resize();
 
         function getMouseEvent(e) {

--- a/src/cellRenderers/SimpleCell.js
+++ b/src/cellRenderers/SimpleCell.js
@@ -80,14 +80,22 @@ var SimpleCell = CellRenderer.extend('SimpleCell', {
         }
         if (alpha(hoverColor) < 1) {
             if (config.isSelected) {
-                selectColor = valOrFunc(config.backgroundSelectionColor, config);
+                selectColor = config.backgroundSelectionColor;
             }
+
             if (alpha(selectColor) < 1) {
-                backgroundColor = valOrFunc(config.backgroundColor, config);
-                if (alpha(backgroundColor) > 0) {
-                    colors.push(backgroundColor);
-                }
+                backgroundColor = config.backgroundColor;
+                if (backgroundColor !== config.columnBackgroundColor) {
+                    var bgAlpha = alpha(backgroundColor);
+                    if (bgAlpha > 0) {
+                        if (bgAlpha < 1) {
+                            gc.clearRect(x, y, width, height);
+                        }
+                        colors.push(backgroundColor);
+                    }
+}
             }
+
             if (selectColor !== undefined) {
                 colors.push(selectColor);
             }
@@ -98,7 +106,7 @@ var SimpleCell = CellRenderer.extend('SimpleCell', {
         layerColors(gc, colors, x, y, width, height);
 
         // draw text
-        var theColor = valOrFunc(config.isSelected ? config.foregroundSelectionColor : config.color, config);
+        var theColor = config.isSelected ? config.foregroundSelectionColor : config.color;
         if (gc.fillStyle !== theColor) {
             gc.fillStyle = theColor;
             gc.strokeStyle = theColor;

--- a/src/lib/Renderer.js
+++ b/src/lib/Renderer.js
@@ -1019,7 +1019,7 @@ var Renderer = Base.extend('Renderer', {
         config.isRowSelected = isRowSelected;
         config.isColumnSelected = isColumnSelected;
         config.isInCurrentSelectionRectangle = grid.isInCurrentSelectionRectangle(x, r);
-        config.columnBackgroundColor = columnProperties.backgroundColor; // could be function?
+        config.columnBackgroundColor = columnProperties.backgroundColor;
 
         if (grid.mouseDownState) {
             config.mouseDown = grid.mouseDownState.gridCell.equals(cellEvent.gridCell);

--- a/src/lib/Renderer.js
+++ b/src/lib/Renderer.js
@@ -524,6 +524,7 @@ var Renderer = Base.extend('Renderer', {
         gc.beginPath();
 
         this.paintCells(gc);
+        this.paintGridlines(gc);
         this.renderOverrides(gc);
         this.renderLastSelection(gc);
         gc.closePath();
@@ -819,7 +820,9 @@ var Renderer = Base.extend('Renderer', {
             dataCell = cellEvent.dataCell,
             vc, visibleColumns = this.visibleColumns,
             vr, visibleRows = this.visibleRows,
-            clipHeight = this.getBounds().height;
+            clipHeight = this.getBounds().height,
+            lineWidth = this.grid.properties.lineWidth,
+            lineColor = this.grid.properties.lineColor;
 
         this.buttonCells = {};
 
@@ -842,11 +845,20 @@ var Renderer = Base.extend('Renderer', {
 
             gc.save();
 
-            // Clip to visible portion of column to prevent overflow to right. Previously we clipped to entire visible grid and dealt with overflow by overpainting with next column. However, this strategy fails when transparent background (no background color).
-            // TODO: if extra clip() calls per column affect performance (not the clipping itself which was happening anyway, but the clip calls which set up the clipping), use previous strategy when there is a background color
+            // Clip to visible portion of column to prevent text from overflowing to right.
+            // (Text never overflows to left because text starting point is never < 0.)
+            // (The reason we don't clip to the left is for cell renderers that rerender to the left to produce a merged cell effect, such as grouped column header.)
             gc.beginPath();
             gc.rect(0, 0, bounds.x + bounds.width, clipHeight);
             gc.clip();
+
+            gc.fillStyle = cellEvent.column.properties.backgroundColor;
+            gc.fillRect(bounds.x, 0, bounds.width, clipHeight);
+
+            if (this.grid.properties.gridLinesV) {
+                gc.fillStyle = lineColor;
+                gc.fillRect(bounds.x - lineWidth, 0, lineWidth, clipHeight);
+            }
 
             // For each row of each subgrid (of each column)...
             for (
@@ -889,6 +901,24 @@ var Renderer = Base.extend('Renderer', {
         }
 
         setNumberColumnWidth(gc, behavior, this.grid.getRowCount());
+    },
+
+    /**
+     * @memberOf Renderer.prototype
+     * @desc We opted to not paint borders for each cell as that was extremely expensive. Instead we draw gridlines here. Also we record the widths and heights for later.
+     * @param {CanvasRenderingContext2D} gc
+     */
+    paintGridlines: function(gc) {
+        if (this.grid.properties.gridLinesH) {
+            var viewWidth = this.visibleColumns[this.visibleColumns.length - 1].right,
+                lineWidth = this.grid.properties.lineWidth;
+
+            gc.fillStyle = this.grid.properties.lineColor;
+
+            this.visibleRows.forEach(function(visibleRow) {
+                gc.fillRect(0, visibleRow.bottom, viewWidth, lineWidth);
+            });
+        }
     },
 
     /**
@@ -989,6 +1019,7 @@ var Renderer = Base.extend('Renderer', {
         config.isRowSelected = isRowSelected;
         config.isColumnSelected = isColumnSelected;
         config.isInCurrentSelectionRectangle = grid.isInCurrentSelectionRectangle(x, r);
+        config.columnBackgroundColor = columnProperties.backgroundColor; // could be function?
 
         if (grid.mouseDownState) {
             config.mouseDown = grid.mouseDownState.gridCell.equals(cellEvent.gridCell);


### PR DESCRIPTION
Instead of doing this (v1.2.1):
* Set CSS backgroundColor style of canvas element to "line color."
* Draw a separate little rect for each cell.

We now do this (v1.2.2, proposed):
* Draw a single rect for the column.
* Draw a vertical line to left of each column rect.
* Draw a cell rect when and only when the background color of the cell differs from the column.
* After all columns are rendered, draw a horizontal line below each visible row.

Also retired feature where `config.backgroundColor`, `config.backgroundSelectionColor`, and `config.foregroundSelectionColor` can all be functions instead of strings. These are the only such properties that allow this. I suspect this feature preceded `getCell` because we never use it and it could also be done in`getCell`.