### PR TITLE
GRID-373: Grid state, continued (part 2)

### DIFF
--- a/add-ons/drill-down.js
+++ b/add-ons/drill-down.js
@@ -5,7 +5,7 @@
 /**
  * Methods for programmatic drill-down manipulation.
  *
- * Intended to be mixed into Hypergrid's in-memory data model object (./src/dataModels/JSON.js) using the included {@link drillDown.mixInTo}
+ * Intended to be mixed into Hypergrid's in-memory data model object ({@link dataModels.JSON}) using the included {@link drillDown.mixInTo}
  * _Do not use directly._
  *
  * For example, you can mix it into the data model prototype like this:

--- a/add-ons/group-view.js
+++ b/add-ons/group-view.js
@@ -196,7 +196,7 @@ GroupView.prototype = {
 
 /**
  * Force `EmptyCell` renderer on parent rows.
- * @this {DataModel} - bound above
+ * @this {dataModelAPI} - bound above
  * @param {function} defaultGetCell - bound above
  * @param {object} config
  * @param {string} rendererName

--- a/add-ons/totals-toolkit/mix-ins/behavior.js
+++ b/add-ons/totals-toolkit/mix-ins/behavior.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 
-    /** @typedef {*[]} valueList
+    /** @typedef {Array} valueList
      * @desc One of:
      * * `activeColumnsList` falsy - Array of row values semantically congruent to `this.columns`.
      * * `activeColumnsList` truthy - Array of row values semantically congruent to `this.allColumns`.
@@ -43,7 +43,7 @@ module.exports = {
      * @summary Get the top total row(s).
      * @returns {valueList[]}
      * @param {boolean} [activeColumnsList=false]
-     * @returns {valueList|*[]} Full data row object, or object containing just the "active" columns, per `activeColumnsList`.
+     * @returns {valueList|Array} Full data row object, or object containing just the "active" columns, per `activeColumnsList`.
      * @memberOf Behavior.prototype
      */
     getTopTotals: function(activeColumnsList) {

--- a/css/grid.css
+++ b/css/grid.css
@@ -2,6 +2,13 @@
     position: relative;
     height: 500px;
 }
+.hypergrid-container > div:first-child {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+}
 .hypergrid-textfield {
     position: absolute;
     font-size: 12px;

--- a/src/Base.js
+++ b/src/Base.js
@@ -43,4 +43,24 @@ Base.prototype.unwrap = function(value) {
 Base.prototype.mixIn = require('overrider').mixIn;
 
 
+/**
+ * @method
+ * @summary Instantiate an object with discrete + variable args.
+ * @desc The discrete args are passed first, followed by the variable args.
+ * @param {function} Constructor
+ * @param {Array} variableArgArray
+ * @param {...*} discreteArgs
+ * @returns {object} Object of type `Constructor` newly constructor using the arguments in `arrayOfArgs`.
+ */
+Base.prototype.createApply = function(Constructor, variableArgArray, discreteArgs) {
+    var discreteArgArray = Array.prototype.slice.call(arguments, 2),
+        args = [null] // null is context for `bind` call below
+            .concat(discreteArgArray) // discrete arguments
+            .concat(variableArgArray), // variable arguments
+        BoundConstructor = Constructor.bind.apply(Constructor, args);
+
+    return new BoundConstructor;
+};
+
+
 module.exports = Base;

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -39,19 +39,26 @@ var EDGE_STYLES = ['top', 'bottom', 'left', 'right'],
  * * A function returning a schema array. Called at filter reset time with behavior as context.
  * * Omit to generate a basic schema from `this.behavior.columns`.
  * @param {Behavior} [options.Behavior=JSON] - A grid behavior (descendant of Behavior "class").
+ *
  * @param {pluginSpec|pluginSpec[]} [options.plugins]
- * @param {DataModels[]} [options.subgrids]
- * @param {string} [options.localization=Hypergrid.localization]
+ *
+ * @param {subgridSpec[]} [options.subgrids]
+ *
  * @param {string|Element} [options.container] - CSS selector or Element
+ *
+ * @param {string} [options.localization=Hypergrid.localization]
  * @param {string|string[]} [options.localization.locale=Hypergrid.localization.locale] - The default locale to use when an explicit `locale` is omitted from localizer constructor calls. Passed to Intl.NumberFomrat` and `Intl.DateFomrat`. See {@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation|Locale identification and negotiation} for more information.
  * @param {string} [options.localization.numberOptions=Hypergrid.localization.numberOptions] - Options passed to `Intl.NumberFormat` for creating the basic "number" localizer.
  * @param {string} [options.localization.dateOptions=Hypergrid.localization.dateOptions] - Options passed to `Intl.DateFomrat` for creating the basic "date" localizer.
+ *
  * @param {object} [options.schema]
+ *
  * @param {object} [options.margin] - Optional canvas "margins" applied to containing div as .left, .top, .right, .bottom. (Default values actually derive from 'grid' stylesheet's `.hypergrid-container` rule.)
  * @param {string} [options.margin.top='0px']
  * @param {string} [options.margin.right='0px']
  * @param {string} [options.margin.bottom='0px']
  * @param {string} [options.margin.left='0px']
+ *
  * @param {object} [options.boundingRect] - Optional grid container size & position. (Default values actually derive from 'grid' stylesheet's `.hypergrid-container > div:first-child` rule.)
  * @param {string} [options.boundingRect.height='500px']
  * @param {string} [options.boundingRect.width='auto']
@@ -350,8 +357,8 @@ var Hypergrid = Base.extend('Hypergrid', {
      *
      * Plugins may have both `preinstall` _and_ `install` methods, in which case both will be called. However, note that in any case, `install` methods on object API plugins are ignored.
      *
-     * @this {Hypergrid|Hypergrid.prototype}
-     * @param {pluginSpec|pluginSpec[]} [plugins] - The plugins to install. This call is a no-op if omitted.
+     * @this {Hypergrid}
+     * @param {pluginSpec|pluginSpec[]} [plugins] - The plugins to install. If omitted, the call is a no-op.
      */
     installPlugins: function(plugins) {
         var shared = this === Hypergrid.prototype; // Do shared ("preinstalled") plugins (if any)
@@ -363,7 +370,7 @@ var Hypergrid = Base.extend('Hypergrid', {
         }
 
         plugins.forEach(function(plugin) {
-            var name, args, hash, BoundConstructor;
+            var name, args, hash;
 
             if (!plugin) {
                 return; // ignore falsy plugin spec
@@ -410,9 +417,7 @@ var Hypergrid = Base.extend('Hypergrid', {
                 hash = this.plugins;
                 if (typeof plugin === 'function') {
                     // Install "object API" by instantiating
-                    args.unshift(null); // context for the `bind` call below
-                    BoundConstructor = plugin.bind.apply(plugin, args);
-                    plugin = new BoundConstructor;
+                    plugin = this.createApply(plugin, args);
                 } else if (plugin.install) {
                     // Install "simple API" by calling its `install` method
                     plugin.install.apply(plugin, args);

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -129,7 +129,7 @@ var Hypergrid = Base.extend('Hypergrid', {
          * For the dictionary of _shared_ plugins, see {@link Hypergrid.plugins|plugins} (a property of the constructor).
          * @example
          * var instancePlugins = myGrid.plugins;
-         * var instancePlugins = this.plugins // internal use
+         * var instancePlugins = this.plugins; // internal use
          * var myInstancePlugin = myGrid.plugins.myInstancePlugin;
          * @type {object}
          * @memberOf Hypergrid#
@@ -359,6 +359,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      *
      * @this {Hypergrid}
      * @param {pluginSpec|pluginSpec[]} [plugins] - The plugins to install. If omitted, the call is a no-op.
+     * @memberOf Hypergrid#
      */
     installPlugins: function(plugins) {
         var shared = this === Hypergrid.prototype; // Do shared ("preinstalled") plugins (if any)
@@ -445,6 +446,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * * `key` - name of the plugin to be uninstalled (_i.e.,_ key in `plugins`)
      * * `plugins` - the plugins hash (a.k.a. `grid.plugins`)
      * @param {string|stirng[]} [pluginNames] If provided, limit uninstall to the named plugin (string) or plugins (string[]).
+     * @memberOf Hypergrid#
      */
     uninstallPlugins: function(pluginNames) {
         if (!pluginNames) {
@@ -494,11 +496,11 @@ var Hypergrid = Base.extend('Hypergrid', {
     },
 
     isRowResizeable: function() {
-        return this.properties.rowResize;
+        return this.deprecated('isRowResizeable()', 'properties.rowResize', 'v1.2.10');
     },
 
     isCheckboxOnlyRowSelections: function() {
-        return this.properties.checkboxOnlyRowSelections;
+        return this.deprecated('isCheckboxOnlyRowSelections()', 'properties.checkboxOnlyRowSelections', 'v1.2.10');
     },
 
     /**
@@ -864,7 +866,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @returns {boolean} In HiDPI mode (has an attribute as such).
      */
     useHiDPI: function() {
-        return this.properties.useHiDPI !== false;
+        return this.deprecated('useHiDPI()', 'properties.useHiDPI', 'v1.2.10');
     },
 
     /**
@@ -1749,7 +1751,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * > There used to be a bug in Chrome that caused severe slow down on bit blit of large images, so this HiDPI needed to be optional.
      */
     toggleHiDPI: function() {
-        if (this.useHiDPI()) {
+        if (this.properties.useHiDPI) {
             this.removeAttribute('hidpi');
         } else {
             this.setAttribute('hidpi', null);
@@ -1759,22 +1761,21 @@ var Hypergrid = Base.extend('Hypergrid', {
 
     /**
      * @memberOf Hypergrid#
-     * @returns {number} Te HiDPI ratio.
+     * @returns {number} The HiDPI ratio.
      */
     getHiDPI: function(ctx) {
-        if (window.devicePixelRatio && this.useHiDPI()) {
-            var devicePixelRatio = window.devicePixelRatio || 1;
-            var backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
+        if (window.devicePixelRatio && this.properties.useHiDPI) {
+            var devicePixelRatio = window.devicePixelRatio || 1,
+                backingStoreRatio = ctx.webkitBackingStorePixelRatio ||
                 ctx.mozBackingStorePixelRatio ||
                 ctx.msBackingStorePixelRatio ||
                 ctx.oBackingStorePixelRatio ||
-                ctx.backingStorePixelRatio || 1;
-
-            var ratio = devicePixelRatio / backingStoreRatio;
-            return ratio;
+                ctx.backingStorePixelRatio || 1,
+                result = devicePixelRatio / backingStoreRatio;
         } else {
-            return 1;
+            result = 1;
         }
+        return result;
     },
 
     /**
@@ -2017,10 +2018,6 @@ var Hypergrid = Base.extend('Hypergrid', {
         return mouseDown.x < 0 || mouseDown.y < headerRowCount;
     },
 
-    isHeaderWrapping: function() {
-        return this.properties.headerTextWrapping;
-    },
-
     _getBoundsOfCell: function(x, y) {
         return this.deprecated('_getBoundsOfCell()', 'getBoundsOfCell()', '1.2.0', arguments);
     },
@@ -2044,30 +2041,30 @@ var Hypergrid = Base.extend('Hypergrid', {
     },
 
     isShowRowNumbers: function() {
-        return this.properties.showRowNumbers;
+        return this.deprecated('isShowRowNumbers()', 'properties.showRowNumbers', 'v1.2.10');
     },
     isEditable: function() {
-        return this.properties.editable === true;
+        return this.deprecated('isEditable()', 'properties.editable', 'v1.2.10');
     },
 
     /**
-     * @todo row refac: deprecate in favor of CellEvent.isDataRow
      * @param {integerRowIndex|sectionPoint} rn
      * @returns {boolean}
+     * @memberOf Hypergrid#
      */
-    isGridRow: function(rn) {
-        return rn >= 0 || rn.y >= 0;
+    isGridRow: function(y) {
+        return new this.beahvior.CellEvent(0, y).isDataRow;
     },
 
     isShowHeaderRow: function() {
-        return this.properties.showHeaderRow;
+        return this.deprecated('isShowHeaderRow()', 'properties.showHeaderRow', 'v1.2.10');
     },
     getHeaderRowCount: function() {
         return this.behavior.getHeaderRowCount();
     },
 
     isShowFilterRow: function() {
-        return this.properties.showFilterRow;
+        return this.deprecated('isShowFilterRow()', 'properties.showFilterRow', 'v1.2.10');
     },
 
     hasHierarchyColumn: function() {
@@ -2106,7 +2103,7 @@ var Hypergrid = Base.extend('Hypergrid', {
         sm.selectRow(Math.min(y1, y2), Math.max(y1, y2));
     },
     isRowNumberAutosizing: function() {
-        return this.properties.rowNumberAutosizing;
+        return this.deprecated('isRowNumberAutosizing()', 'properties.rowNumberAutosizing', 'v1.2.10');
     },
     lookupFeature: function(key) {
         return this.behavior.lookupFeature(key);
@@ -2116,8 +2113,7 @@ var Hypergrid = Base.extend('Hypergrid', {
     },
 
     isColumnAutosizing: function() {
-        this.deprecated('isColumnAutosizing', 'Property .isColumnAutosizing has been deprecated as of v1.2.2 in favor of .properties.columnAutosizing === true. (Will be removed in a future version.) Note however that as of v1.2.2 grid.properties.columnAutosizing no longer has the global meaning it had previously and should no longer be referred to directly. Refer to each column\'s `columnAutosizing` property instead.');
-        return this.properties.columnAutosizing === true;
+        return this.deprecated('isColumnAutosizing()', 'columnAutosizing', 'v1.2.2', arguments, 'Note however that as of v1.2.2 columnAutosizing grid property no longer has the global meaning it had previously and should no longer be referred to directly. Refer to each column\'s `columnAutosizing` property instead.');
     },
 
     newPoint: function(x, y) {
@@ -2207,6 +2203,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * * When `options` defined, first of:
      *   * mix-in: default preset members + `options` members
      *   * `options` verbatim when default preset undefined
+     * @memberOf Hypergrid#
      */
     setDialogOptions: function(dialogName, options) {
         if (typeof dialogName === 'object') {
@@ -2230,6 +2227,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * Options objects are remembered for subsequent use. Alternatively, they can be preset by calling {@link Hypergrid#setDialogOptions|setDialogOptions}.
      * @param {string} dialogName
      * @param {object} [options] - If omitted, use the options object previously given here (or to {@link Hypergrid#setDialogOptions|setDialogOptions}), if any. In any case, the resultant options object, if any, is mixed into the default options object, if there is one.
+     * @memberOf Hypergrid#
      */
     openDialog: function(dialogName, options) {
         if (!this.abortEditing()) { return; }
@@ -2276,6 +2274,17 @@ function findOrCreateContainer(boundingRect) {
     return div;
 }
 
+function setStyles(el, style, keys) {
+    if (style) {
+        var elStyle = el.style;
+        keys.forEach(function(key) {
+            if (style[key] !== undefined) {
+                elStyle[key] = style[key];
+            }
+        });
+    }
+}
+
 function headerFormatter(value, config) {
     var sortString = this.behavior.dataModel.getSortImageForColumn(config.x);
 
@@ -2296,6 +2305,9 @@ function headerFormatter(value, config) {
 }
 
 /**
+ * @name plugins
+ * @memberOf Hypergrid
+ * @type {object}
  * @summary Hash of references to shared plug-ins.
  * @desc Dictionary of shared (pre-installed) plug-ins. Used internally, primarily to avoid reinstallations. See examples for how to reference (albeit there is normally no need to reference plugins directly).
  *
@@ -2312,19 +2324,19 @@ function headerFormatter(value, config) {
  * @example
  * var allSharedPlugins = Hypergrid.plugins;
  * var mySharedPlugin = Hypergrid.plugins.mySharedPlugin;
- * @type {object}
  */
 Hypergrid.plugins = {};
 
 /**
+ * @name localization
+ * @memberOf Hypergrid
+ * @type {object}
  * @summary Shared localization defaults for all grid instances.
  * @desc These property values are overridden by those supplied in the `Hypergrid` constructor's `options.localization`.
  * @property {string|string[]} [locale] - The default locale to use when an explicit `locale` is omitted from localizer constructor calls. Passed to Intl.NumberFormat` and `Intl.DateFormat`. See {@ https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation|Locale identification and negotiation} for more information. Omitting will use the runtime's local language and region.
  * @property {object} [numberOptions] - Options passed to `Intl.NumberFormat` for creating the basic "number" localizer.
  * @property {object} [dateOptions] - Options passed to `Intl.DateFormat` for creating the basic "date" localizer.
- * @type {object}
  */
-
 Hypergrid.localization = {
     locale: 'en-US',
     numberOptions: { maximumFractionDigits: 0 }

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -262,7 +262,7 @@ var Behavior = Base.extend('Behavior', {
      * @returns {object}
      */
     getPrivateState: function() {
-        return this.deprecate('getPrivateState()', 'grid.properties', '1.2.0');
+        return this.deprecated('getPrivateState()', 'grid.properties', '1.2.0');
     },
 
     //this is effectively a clone, with certain things removed....

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -7,7 +7,6 @@ var Point = require('rectangular').Point;
 var Base = require('../Base');
 var Column = require('./Column');
 var cellEventFactory = require('./../lib/cellEventFactory');
-var dataModels = require('../dataModels');
 var dialogs = require('../dialogs');
 
 var noExportProperties = [
@@ -34,12 +33,12 @@ var Behavior = Base.extend('Behavior', {
      * @param {Hypergrid} grid
      * @param {object} [options] - _(See {@link behaviors.JSON#setData} for additional options.)_
      * @param {DataModels[]} [options.subgrids]
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     initialize: function(grid, options) {
         /**
          * @type {Hypergrid}
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          */
         this.grid = grid;
 
@@ -52,7 +51,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @desc create the feature chain - this is the [chain of responsibility](http://c2.com/cgi/wiki?ChainOfResponsibilityPattern) pattern.
      * @param {Hypergrid} grid
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     initializeFeatureChain: function(grid) {
         var self = this;
@@ -61,7 +60,7 @@ var Behavior = Base.extend('Behavior', {
          * @summary Hash of feature class names.
          * @desc Built here but otherwise not in use.
          * @type {object}
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          */
         this.featureMap = {};
 
@@ -75,7 +74,7 @@ var Behavior = Base.extend('Behavior', {
                  * @summary Controller chain of command.
                  * @desc Each feature is linked to the next feature.
                  * @type {Feature}
-                 * @memberOf Behavior.prototype
+                 * @memberOf Behavior#
                  */
                 self.featureChain = newFeature;
             }
@@ -92,8 +91,8 @@ var Behavior = Base.extend('Behavior', {
             this.dataModel.reset();
         } else {
             /**
-             * @type {DataModel}
-             * @memberOf Behavior.prototype
+             * @type {dataModelAPI}
+             * @memberOf Behavior#
              */
             this.dataModel = this.getNewDataModel(options);
         }
@@ -109,14 +108,9 @@ var Behavior = Base.extend('Behavior', {
         /**
          * Ordered list of subgrids to render.
          * @type {subgridSpec[]}
+         * @memberOf Hypergrid#
          */
-        this.subgrids = options.subgrids || [
-            dataModels.HeaderSubgrid,
-            dataModels.FilterSubgrid,
-            [dataModels.SummarySubgrid, { name: 'topTotals' }],
-            this.dataModel,
-            [dataModels.SummarySubgrid, { name: 'bottomTotals' }]
-        ];
+        this.subgrids = options.subgrids || this.defaultSubgridSpecs;
     },
 
     get renderedColumnCount() {
@@ -130,13 +124,13 @@ var Behavior = Base.extend('Behavior', {
     clearColumns: function() {
         /**
          * @type {Column[]}
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          */
         this.columns = [];
 
         /**
          * @type {Column[]}
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          */
         this.allColumns = [];
 
@@ -154,6 +148,7 @@ var Behavior = Base.extend('Behavior', {
      * The "grid index" given a "data index" (or column object)
      * @param {Column|number} columnOrIndex
      * @returns {undefined|number} The grid index of the column or undefined if column not in grid.
+     * @memberOf Hypergrid#
      */
     getActiveColumnIndex: function(columnOrIndex) {
         var index = columnOrIndex instanceof Column ? columnOrIndex.index : columnOrIndex;
@@ -208,6 +203,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @param {Column|number} columnOrIndex - The column or active column index.
      * @param width
+     * @memberOf Hypergrid#
      */
     setColumnWidth: function(columnOrIndex, width) {
         var column = columnOrIndex >= -2 ? this.getActiveColumn(columnOrIndex) : columnOrIndex;
@@ -226,16 +222,15 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @deprecated
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
-    applyAnalytics: function() {
+    reindex: function() {
         this.dataModel.reindex();
         this.shapeChanged();
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc utility function to empty an object of its members
      * @param {object} obj - the object to empty
      * @param {boolean} [exportProps]
@@ -258,7 +253,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc getter for a [Memento](http://c2.com/cgi/wiki?MementoPattern) Object
      * @returns {object}
      */
@@ -273,7 +268,7 @@ var Behavior = Base.extend('Behavior', {
         return copy;
     },
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc clear all table state
      */
     clearState: function() {
@@ -281,7 +276,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Restore this table to a previous state.
      * See the [memento pattern](http://c2.com/cgi/wiki?MementoPattern).
      * @param {Object} memento - an encapsulated representation of table state
@@ -339,7 +334,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Rebuild the column order indexes
      * @param {Array} columnIndexes - list of column indexes
      * @param {Boolean} [silent=false] - whether to trigger column changed event
@@ -377,7 +372,7 @@ var Behavior = Base.extend('Behavior', {
      *
      * _Promoted left one arg position when `isActiveColumnIndexes` omitted + one position when `referenceIndex` omitted._
      *
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     showColumns: function(isActiveColumnIndexes, columnIndexes, referenceIndex, allowDuplicateColumns) {
         // Promote args when isActiveColumnIndexes omitted
@@ -440,7 +435,7 @@ var Behavior = Base.extend('Behavior', {
      * * **Array of column indexes** - Adds multiple consecutive columns at insertion point.
      *
      * _This required parameter is promoted left one arg position when `isActiveColumnIndexes` omitted._
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     hideColumns: function(isActiveColumnIndexes, columnIndexes) {
         var args = Array.prototype.slice.call(arguments); // Convert to array so we can add an argument (element)
@@ -449,7 +444,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc fetch the value for a property key
      * @returns {*} The value of the given property.
      * @param {string} key - a property name
@@ -460,7 +455,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc A specific cell was clicked; you've been notified.
      * @param {Object} event - all event information
      * @return {boolean} Clicked in a drill-down column.
@@ -473,7 +468,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc A specific cell was le double-clicked; you've been notified.
      * @param {Point} cell - point of cell coordinates
      * @param {Object} event - all event information
@@ -489,7 +484,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @param {CellEvent|number} xOrCellEvent - Grid column coordinate.
      * @param {number} [y] - Grid row coordinate. Omit if `xOrCellEvent` is a CellEvent.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     getValue: function(xOrCellEvent, y) {
         switch (arguments.length) {
@@ -506,7 +501,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc update the data at point x, y with value
      * @return The data.
      * @param {CellEvent|number} xOrCellEvent - Grid column coordinate.
@@ -537,7 +532,7 @@ var Behavior = Base.extend('Behavior', {
      * @param {CellEvent|number} xOrCellEvent - Data x coordinate.
      * @param {number} [y] - Grid row coordinate. _Omit when `xOrCellEvent` is a `CellEvent`._
      * @returns {undefined|object} The "own" properties of the cell at x,y in the grid. If the cell does not own a properties object, returns `undefined`.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     getCellOwnProperties: function(xOrCellEvent, y) {
         switch (arguments.length) {
@@ -558,7 +553,7 @@ var Behavior = Base.extend('Behavior', {
      * @param {CellEvent|number} xOrCellEvent - Data x coordinate.
      * @param {number} [y] - Grid row coordinate. _Omit when `xOrCellEvent` is a `CellEvent`._
      * @return {object} The properties of the cell at x,y in the grid.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     getCellProperties: function(xOrCellEvent, y) {
         switch (arguments.length) {
@@ -578,7 +573,7 @@ var Behavior = Base.extend('Behavior', {
      * @param {number} [y] - Grid row coordinate._ Omit when `xOrCellEvent` is a `CellEvent`._
      * @param {string} key - Name of property to get. _When `y` omitted, this param promoted to 2nd arg._
      * @return {object} The specified property for the cell at x,y in the grid.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     getCellProperty: function(xOrCellEvent, y, key) {
         switch (arguments.length) {
@@ -592,7 +587,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc update the data at point x, y with value
      * @param {CellEvent|number} xOrCellEvent - Data x coordinate.
      * @param {number} [y] - Grid row coordinate. _Omit when `xOrCellEvent` is a `CellEvent`._
@@ -609,7 +604,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc update the data at point x, y with value
      * @param {CellEvent|number} xOrCellEvent - Data x coordinate.
      * @param {number} [y] - Grid row coordinate. _Omit when `xOrCellEvent` is a `CellEvent`._
@@ -632,7 +627,7 @@ var Behavior = Base.extend('Behavior', {
      * @param {number} [y] - Grid row coordinate. _Omit when `xOrCellEvent` is a `CellEvent`._
      * @param {string} key - Name of property to get. _When `y` omitted, this param promoted to 2nd arg._
      * @param value
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     setCellProperty: function(xOrCellEvent, y, key, value) {
         switch (arguments.length) {
@@ -645,23 +640,12 @@ var Behavior = Base.extend('Behavior', {
         }
     },
 
-    /**
-     * @summary Gets the number of rows in the hypergrid.
-     * @dsc Defined as the sum of all rows from all subgrids.
-     * @memberOf Behavior.prototype
-     */
-    getRowCount: function() {
-        return this.subgrids.reduce(function(sum, subgrid) {
-            return sum + subgrid.getRowCount();
-        }, 0);
-    },
-
     getUnfilteredRowCount: function() {
         return this.deprecated('getUnfilteredRowCount()', null, '1.2.0', arguments, 'No longer supported');
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {number} The height in pixels of the fixed rows area  of the hypergrid.
      */
     getFixedRowsHeight: function() {
@@ -674,9 +658,9 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @param {number} rowIndex - Data row coordinate local to datsModel.
-     * @param {DataModel} [dataModel=this.dataModel]
+     * @param {dataModelAPI} [dataModel=this.dataModel]
      */
     getRowHeight: function(rowIndex, dataModel) {
         var rowData = (dataModel || this.dataModel).getRow(rowIndex);
@@ -684,7 +668,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc The value is lazily initialized and comes from the properties mechanism for '`defaultRowHeight`', which should be ~20px.
      * @returns {number} The row height in pixels.
      */
@@ -693,11 +677,11 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc set the pixel height of a specific row
      * @param {number} rowIndex - Data row coordinate local to datsModel.
      * @param {number} height - pixel height
-     * @param {DataModel} [dataModel=this.dataModel]
+     * @param {dataModelAPI} [dataModel=this.dataModel]
      */
     setRowHeight: function(rowIndex, height, dataModel) {
         var rowData = (dataModel || this.dataModel).getRow(rowIndex);
@@ -708,7 +692,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc This will allow 'floating' fixed rows.
      * @return {number} The maximum height of the fixed rows area in the hypergrid.
      */
@@ -717,7 +701,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {number} The width of the fixed column area in the hypergrid.
      */
     getFixedColumnsWidth: function() {
@@ -730,7 +714,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc This exists to support "floating" columns.
      * @return {number} The total width of the fixed columns area.
      */
@@ -739,7 +723,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Set the scroll position in vertical dimension and notify listeners.
      * @param {number} y - the new y value
      */
@@ -749,7 +733,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Set the scroll position in horizontal dimension and notify listeners.
      * @param {number} x - the new x value
      */
@@ -759,7 +743,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc The fixed row area has been clicked, massage the details and call the real function.
      * @param {Hypergrid} grid
      * @param {Object} mouse - event details
@@ -772,7 +756,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc The fixed column area has been clicked, massage the details and call the real function.
      * @param {Hypergrid} grid
      * @param {Object} mouse - event details
@@ -791,7 +775,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate setting the cursor up the feature chain of responsibility
      * @param {Hypergrid} grid
      */
@@ -801,7 +785,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling mouse move to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -814,7 +798,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling tap to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -827,7 +811,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling tap to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -841,7 +825,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling wheel moved to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -854,7 +838,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling mouse up to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -867,7 +851,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling mouse drag to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -880,7 +864,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling key down to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -893,7 +877,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling key up to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -906,7 +890,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling double click to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -919,7 +903,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling double click to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {string[]} [options] - Forwarded to dialog constructor.
@@ -929,7 +913,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling mouse down to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -942,7 +926,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc delegate handling mouse exit to the feature chain of responsibility
      * @param {Hypergrid} grid
      * @param {Object} event - the event details
@@ -955,25 +939,25 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc I've been notified that the behavior has changed.
      */
     changed: function() { this.grid.behaviorChanged(); },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc The dimensions of the grid data have changed. You've been notified.
      */
     shapeChanged: function() { this.grid.behaviorShapeChanged(); },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc The dimensions of the grid data have changed. You've been notified.
      */
     stateChanged: function() { this.grid.behaviorStateChanged(); },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {boolean} Can re-order columns.
      */
     isColumnReorderable: function() {
@@ -983,7 +967,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @param {index} x - Data x coordinate.
      * @return {Object} The properties for a specific column.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     getColumnProperties: function(x) {
         var column = this.getColumn(x);
@@ -993,7 +977,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * @param {index} x - Data x coordinate.
      * @return {Object} The properties for a specific column.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     setColumnProperties: function(x, properties) {
         var column = this.getColumn(x);
@@ -1008,6 +992,7 @@ var Behavior = Base.extend('Behavior', {
     /**
      * Clears all cell properties of given column or of all columns.
      * @param {number} [x] - Omit for all columns.
+     * @memberOf Behavior#
      */
     clearAllCellProperties: function(x) {
         if (x === undefined) {
@@ -1024,7 +1009,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {string[]} All the currently hidden column header labels.
      */
     getHiddenColumnDescriptors: function() {
@@ -1046,7 +1031,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {integer} The number of fixed columns.
      */
     getFixedColumnCount: function() {
@@ -1054,7 +1039,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc set the number of fixed columns
      * @param {number} n - the integer count of how many columns to be fixed
      */
@@ -1063,7 +1048,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {integer} The number of fixed rows.
      */
     getFixedRowCount: function() {
@@ -1074,7 +1059,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Set the number of fixed rows, which includes (top to bottom order):
      * 1. The header rows
      *    1. The header labels row (optional)
@@ -1091,31 +1076,13 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @summary Gets the number of "header rows".
-     * @desc Defined as the sum of all rows of all subgrids before the (first) data subgrid.
-     * @memberOf behaviors.JSON.prototype
-     */
-    getHeaderRowCount: function() {
-        var result = 0;
-
-        this.subgrids.find(function(subgrid) {
-            if (subgrid.isData) {
-                return true; // stop
-            }
-            result += subgrid.getRowCount();
-        });
-
-        return result;
-    },
-
-    /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc a dnd column has just been dropped, we've been notified
      */
     endDragColumnNotification: function() {},
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {null} the cursor at a specific x,y coordinate
      * @param {number} x - the x coordinate
      * @param {number} y - the y coordinate
@@ -1126,7 +1093,7 @@ var Behavior = Base.extend('Behavior', {
 
     /**
      * Number of _visible_ columns.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {number} The total number of columns.
      */
     getActiveColumnCount: function() {
@@ -1144,13 +1111,13 @@ var Behavior = Base.extend('Behavior', {
      * * `'right'`
      *
      * Cascades to grid.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Quietly set the horizontal scroll position.
      * @param {number} x - The new position in pixels.
      */
     setScrollPositionX: function(x) {
         /**
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          * @type {number}
          */
         this.scrollPositionX = x;
@@ -1161,13 +1128,13 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc Quietly set the vertical scroll position.
      * @param {number} y - The new position in pixels.
      */
     setScrollPositionY: function(y) {
         /**
-         * @memberOf Behavior.prototype
+         * @memberOf Behavior#
          * @type {number}
          */
         this.scrollPositionY = y;
@@ -1178,7 +1145,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {cellEditor} The cell editor for the cell at the given coordinates.
      * @param {CellEvent} editPoint - The grid cell coordinates.
      */
@@ -1191,7 +1158,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {boolean} `true` if we should highlight on hover
      * @param {boolean} isColumnHovered - the column is hovered or not
      * @param {boolean} isRowHovered - the row is hovered or not
@@ -1201,7 +1168,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc this function is a hook and is called just before the painting of a cell occurs
      * @param {window.fin.rectangular.Point} cell
      */
@@ -1210,7 +1177,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc this function is a hook and is called just before the painting of a fixed row cell occurs
      * @param {window.fin.rectangular.Point} cell
      */
@@ -1219,7 +1186,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc this function is a hook and is called just before the painting of a fixed column cell occurs
      * @param {window.fin.rectangular.Point} cell
      */
@@ -1228,7 +1195,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc this function is a hook and is called just before the painting of a top left cell occurs
      * @param {window.fin.rectangular.Point} cell
      */
@@ -1237,7 +1204,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @desc swap src and tar columns
      * @param {number} src - column index
      * @param {number} tar - column index
@@ -1255,7 +1222,7 @@ var Behavior = Base.extend('Behavior', {
     },
 
     /**
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      * @return {object} The object at y index.
      * @param {number} y - the row index of interest
      */
@@ -1305,7 +1272,7 @@ var Behavior = Base.extend('Behavior', {
      * @summary _Getter_
      * @method
      * @returns {dataSourceHelperAPI} The grid's currently assigned filter.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     get filter() {
         return this.dataModel.filter;
@@ -1317,7 +1284,7 @@ var Behavior = Base.extend('Behavior', {
      * @param {dataSourceHelperAPI|undefined|null} filter - One of:
      * * A filter object, turning filter *ON*.
      * * If `undefined` or `null`, the null filter is reassigned to the grid, turning filtering *OFF*.
-     * @memberOf Behavior.prototype
+     * @memberOf Behavior#
      */
     set filter(filter) {
         this.dataModel.filter = filter;
@@ -1366,120 +1333,22 @@ var Behavior = Base.extend('Behavior', {
     },
     getIndexedData: function() {
        this.dataModel.getIndexedData();
-    },
-
-    setInfo: function(messages) {
-        if (this.subgrids.info) {
-            this.subgrids.info.setData(
-                messages instanceof Array ? messages : [messages],
-                this.dataModel.schema
-            );
-            this.grid.behavior.changed();
-        }
-    },
-
-    /**
-     * An array where each element represents a subgrid to be rendered in the hypergrid.
-     *
-     * The list should always include at least one "data" subgrid, typically {@link Behavior#dataModel|dataModel}.
-     * It may also include zero or more other types of subgrids such as header, filter, and summary subgrids.
-     *
-     * This object also serves as a dictionary of subgrids where each dictionary key is one of:
-     * * **`subgrid.name`** (for those that have a defined name, which is presumed to be unique)
-     * * **`subgrid.type`** (not unique, so if you plan on having multiple, name them!)
-     * * **`'data'`** for the one and only data subgrid (which is unnamed and untyped)
-     *
-     * The setter:
-     * * "Enlivens" any constructors
-     * * Reconstructs the dictionary
-     * * Calls {@link Behavior#shapeChanged|shpaeChanged()}.
-     *
-     * @param {subgridSpec[]} subgrids
-     *
-     * @type {DataModel[]}
-     * @memberOf Behavior.prototype
-     */
-    set subgrids(subgrids) {
-        this._subgrids = subgrids = subgrids.map(enlivenSubgrids, this);
-
-        // create the dictionary from the array elements
-        subgrids.forEach(function(subgrid) {
-            // undefined type is data
-            subgrid.type = subgrid.type || 'data';
-
-            // make dictionary entry
-            var key = subgrid.name || subgrid.type;
-            subgrids[key] = subgrids[key] || subgrid; // only save first with this key
-
-            // make isType boolean
-            subgrid['is' + subgrid.type[0].toUpperCase() + subgrid.type.substr(1)] = true;
-        });
-
-        this.shapeChanged();
-    },
-    get subgrids() {
-        return this._subgrids;
     }
 });
 
-/**
- * Maps a `subgridSpec` to a data model.
- * @param {DataModel|Array|function|undefined|null} [subgridSpec] - One of:
- * * **{@link DataModel}** - Mapped to self (passed through as is).
- * * **`Array`** - Mapped to newly instantiated data model: First element is assumed to be a {@link DataModel} constructor to be called with `new` keyword and `this.grid` as first arg and remaining elements as additional args.
- * * **`function`** - Assumed to be a data model constructor. Mapped to newly instantiated data model: The constructor is called with `new` keyword and `this.grid` as only arg.
- * * **`undefined`** - Mapped to the behavior's already-instantiated data model (`this.dataModel`).
- * @returns {DataModel}
- */
-function enlivenSubgrids(subgridSpec) {
-    var result, Constructor, variableArgArray;
-    if (typeof subgridSpec === undefined) {
-        result = this.dataModel;
-    } else if (subgridSpec instanceof Array && subgridSpec.length) {
-        Constructor = derefSubgridRef.call(this, subgridSpec[0]);
-        variableArgArray = subgridSpec.slice(1);
-        result = this.createApply(Constructor, variableArgArray, this.grid);
-    } else if (typeof subgridSpec === 'object') {
-        result = subgridSpec;
-    } else {
-        Constructor = derefSubgridRef.call(this, subgridSpec);
-        result = new Constructor(this.grid);
-    }
-    return result;
-}
-
-function derefSubgridRef(subgridRef) {
-    var Constructor;
-    switch (typeof subgridRef) {
-        case 'string':
-            Constructor = dataModels[subgridRef];
-            break;
-        case 'function':
-            Constructor = subgridRef;
-            break;
-        default:
-            throw new this.HypergridError('Expected subgrid ref to be registered name or constructor, but found ' + typeof subgridSpec + '.');
-    }
-    return Constructor;
-}
+// synonyms
 
 /**
- * @memberOf Behavior.prototype
+ * Synonym of {@link Behavior#reindex}.
+ * @name applyAnalytics
+ * @deprecated
+ * @memberOf Behavior#
  */
-Behavior.prototype.reindex = Behavior.prototype.applyAnalytics;
+Behavior.prototype.applyAnalytics = Behavior.prototype.reindex;
+
+
+// mix-ins
+Behavior.prototype.mixIn(require('./subgrids'));
+
 
 module.exports = Behavior;
-
-/** @typedef {undefined|string|DataModel} subgridRef
- * @desc One of:
- * * **`undefined`** - The behavior's data model (already instantiated).
- * * **`string`** - The name of a registered data model (to be instantiated).
- * * **{@link DataModel}** - A specific data model object (to be instantiated).
- */
-/** @typedef {subgridRef|Array} subgridSpec
- * @desc One of:
- * * **{@link subgridRef}**
- * * **`Array`**:
- *   * first element is a {@link subgridRef}
- *   * remaining elements to be passed to the data model constructor
- */

--- a/src/behaviors/JSON.js
+++ b/src/behaviors/JSON.js
@@ -66,6 +66,7 @@ var JSON = Behavior.extend('behaviors.JSON', {
      * @param key
      * @todo move columnEnum code from core to demo
      * @returns {string}
+     * @memberOf behaviors.JSON.prototype
      */
     columnEnumKey: function(key) {
         return key.replace(REGEX_CAMEL_CASE, '$1_$2').toUpperCase();
@@ -137,6 +138,7 @@ var JSON = Behavior.extend('behaviors.JSON', {
      * @param {string} [whichStash]
      * @param {object} [options] - Takes first argument position when `DataSources` omitted.
      * @param {boolean} [options.apply=true] Apply data transformations to the new data.
+     * @memberOf behaviors.JSON.prototype
      */
     unstashPipeline: function(stash, options) {
         if (typeof stash === 'object') {

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -8,6 +8,7 @@ var FIELD = 'columnProperties.field is deprecated as of v1.1.0 in favor of colum
 /**
  * @this {Column}
  * @returns {object}
+ * @memberOf Column#
  */
 function createColumnProperties() {
     var column = this,

--- a/src/behaviors/index.js
+++ b/src/behaviors/index.js
@@ -1,7 +1,28 @@
 'use strict';
 
+/** @namespace src/behaviors */
+
 module.exports = {
-    Behavior: require('./Behavior'), // abstract base class
+    /**
+     * Abstract base class.
+     * @see {@link Behavior}
+     * @type {Behavior}
+     * @memberOf src/behaviors
+     */
+    Behavior: require('./Behavior'),
+
+    /**
+     * Behavior that services the dataModels/JSON data model.
+     * @see {@link behaviors.JSON}
+     * @type {Behavior}
+     * @memberOf src/behaviors
+     */
     JSON: require('./JSON'),
+
+    /**
+     * Object representing.
+     * @see {@link Column}
+     * @memberOf src/behaviors
+     */
     Column: require('./Column')
 };

--- a/src/behaviors/subgrids.js
+++ b/src/behaviors/subgrids.js
@@ -1,0 +1,162 @@
+'use strict';
+
+
+var dataModels = require('../dataModels');
+
+
+/** @typedef subgridConstructorRef
+ * @summary Type definition.
+ * @desc One of:
+ * * **`function` type** - Assumed to already be a data model constructor.
+ * * **`string` type** - The name of a data model "class" (constructor) registered in the {@link src/dataModels} namespace. Used to look up the constructor in the namespace.
+ */
+
+/** @typedef subgridSpec
+ * @summary Type definition.
+ * @desc One of:
+ * * **`object` type** _(except when an array)_ - Assumed to be a reference to an already-instantiated data model. Used as is.
+ * * **`'data'` special value** - Set to the data subgrid (_i.e.,_ the behavior's already-instantiated data model).
+ * * **{@link subgridConstructorRef}** _(see)_ - The constructor ref is resolved and called with the `new` keyword + a reference to the grid as the sole parameter.
+ * * **`Array` object** — Accommodates data model constructor arguments. The constructor ref is resolved and called with the `new` keyword + a reference to the grid as the first parameter + the remaining elements as additional parameters. (If you don't have remaining elements, don't give an array here; just provide a simple `subgridConstructorRef` instead.) The array should have two or more elements:
+ *   * The first element is a {@link subgridConstructorRef}.
+ *   * Remaining elements are used as additional parameters to the constructor.
+ */
+
+module.exports = {
+    defaultSubgridSpecs: [
+        dataModels.HeaderSubgrid,
+        dataModels.FilterSubgrid,
+        [dataModels.SummarySubgrid, { name: 'topTotals' }],
+        dataModels.InfoSubgrid,
+        'data',
+        [dataModels.SummarySubgrid, { name: 'bottomTotals' }]
+    ],
+    /**
+     * An array where each element represents a subgrid to be rendered in the hypergrid.
+     *
+     * The list should always include at least one "data" subgrid, typically {@link Behavior#dataModel|dataModel}.
+     * It may also include zero or more other types of subgrids such as header, filter, and summary subgrids.
+     *
+     * This object also serves as a dictionary of subgrids where each dictionary key is one of:
+     * * **`subgrid.name`** (for those that have a defined name, which is presumed to be unique)
+     * * **`subgrid.type`** (not unique, so if you plan on having multiple, name them!)
+     * * **`'data'`** for the (one and only) data subgrid (which is unnamed and untyped)
+     *
+     * The setter:
+     * * "Enlivens" any constructors (see {@link Behavior~createSubgrid|createSubgrid} for details.
+     * * Reconstructs the dictionary
+     * * Calls {@link Behavior#shapeChanged|shapeChanged()}.
+     *
+     * @param {subgridSpec[]} subgridSpecs
+     *
+     * @type {dataModelAPI[]}
+     *
+     * @memberOf Behavior#
+     */
+    set subgrids(subgridSpecs) {
+        var subgrids = this._subgrids = subgridSpecs.map(createSubgrid, this);
+
+        // create the dictionary from the array elements
+        subgrids.forEach(function(subgrid) {
+            // undefined type is data
+            subgrid.type = subgrid.type || 'data';
+
+            // make dictionary entry
+            var key = subgrid.name || subgrid.type;
+            subgrids[key] = subgrids[key] || subgrid; // only save first with this key
+
+            // make isType boolean
+            subgrid['is' + subgrid.type[0].toUpperCase() + subgrid.type.substr(1)] = true;
+        });
+
+        this.shapeChanged();
+    },
+    get subgrids() {
+        return this._subgrids;
+    },
+
+    /**
+     * @summary Gets the number of rows in the hypergrid.
+     * @dsc Defined as the sum of all rows from all subgrids.
+     * @memberOf Behavior.prototype
+     */
+    getRowCount: function() {
+        return this.subgrids.reduce(function(sum, subgrid) {
+            return sum + subgrid.getRowCount();
+        }, 0);
+    },
+
+    /**
+     * @summary Gets the number of "header rows".
+     * @desc Defined as the sum of all rows of all subgrids before the (first) data subgrid.
+     * @memberOf behaviors.JSON.prototype
+     */
+    getHeaderRowCount: function() {
+        var result = 0;
+
+        this.subgrids.find(function(subgrid) {
+            if (subgrid.isData) {
+                return true; // stop
+            }
+            result += subgrid.getRowCount();
+        });
+
+        return result;
+    },
+
+    setInfo: function(messages) {
+        if (this.subgrids.info) {
+            this.subgrids.info.setData(
+                messages instanceof Array ? messages : [messages],
+                this.dataModel.schema
+            );
+            this.grid.behavior.changed();
+        }
+    },
+};
+
+/**
+ * @summary Maps a `subgridSpec` to a data model.
+ * @desc The spec may describe either an existing data model, or a constructor for a new data model.
+ * @param {subgridSpec} spec
+ * @returns {dataModelAPI} A data model.
+ * @memberOf Behavior~
+ */
+function createSubgrid(spec) {
+    var result, Constructor, variableArgArray;
+    if (spec === 'data') {
+        result = this.dataModel;
+    } else if (spec instanceof Array && spec.length) {
+        Constructor = derefSubgridRef.call(this, spec[0]);
+        variableArgArray = spec.slice(1);
+        result = this.createApply(Constructor, variableArgArray, this.grid);
+    } else if (typeof spec === 'object') {
+        result = spec;
+    } else {
+        Constructor = derefSubgridRef.call(this, spec);
+        result = new Constructor(this.grid);
+    }
+    return result;
+}
+
+/**
+ * @summary Resolves a subgrid constructor reference.
+ * @desc The ref is resolved to a data model constructor.
+ * @param {subgridConstructorRef} ref
+ * @returns {DataModel} A data model constructor.
+ * @memberOf Behavior~
+ */
+function derefSubgridRef(ref) {
+    var Constructor;
+    switch (typeof ref) {
+        case 'string':
+            Constructor = dataModels[ref];
+            break;
+        case 'function':
+            Constructor = ref;
+            break;
+        default:
+            throw new this.HypergridError('Expected subgrid ref to be registered name or constructor, but found ' + typeof ref + '.');
+    }
+    return Constructor;
+}

--- a/src/dataModels/FilterSubgrid.js
+++ b/src/dataModels/FilterSubgrid.js
@@ -1,18 +1,33 @@
 'use strict';
 
-function FilterRow(grid) {
+/**
+ * @implements dataModelAPI
+ * @param {Hypergrid} grid
+ * @param {object} [options]
+ * @param {string} [options.name]
+ * @constructor
+ */
+function FilterSubgrid(grid, options) {
     this.grid = grid;
     this.behavior = grid.behavior;
+
+    /**
+     * @type {dataRowObject}
+     */
     this.dataRow = {}; // for meta data (__HEIGHT)
+
+    if (options && options.name) {
+        this.name = options.name;
+    }
 }
 
-FilterRow.prototype = {
-    constructor: FilterRow.prototype.constructor,
+FilterSubgrid.prototype = {
+    constructor: FilterSubgrid.prototype.constructor,
 
     type: 'filter',
 
     getRowCount: function() {
-        return this.grid.isShowFilterRow() ? 1 : 0;
+        return this.grid.properties.showFilterRow ? 1 : 0;
     },
 
     getValue: function(x, y) {
@@ -28,4 +43,4 @@ FilterRow.prototype = {
     }
 };
 
-module.exports = FilterRow;
+module.exports = FilterSubgrid;

--- a/src/dataModels/HeaderSubgrid.js
+++ b/src/dataModels/HeaderSubgrid.js
@@ -1,18 +1,33 @@
 'use strict';
 
-function HeaderRow(grid) {
+/**
+ * @implements dataModelAPI
+ * @param {Hypergrid} grid
+ * @param {object} [options]
+ * @param {string} [options.name]
+ * @constructor
+ */
+function HeaderSubgrid(grid, options) {
     this.grid = grid;
     this.behavior = grid.behavior;
-    this.dataRow = {}; // for meta data (__ROW_HEIGHT)
+
+    /**
+     * @type {dataRowObject}
+     */
+    this.dataRow = {}; // for meta data (__HEIGHT)
+
+    if (options && options.name) {
+        this.name = options.name;
+    }
 }
 
-HeaderRow.prototype = {
-    constructor: HeaderRow.prototype.constructor,
+HeaderSubgrid.prototype = {
+    constructor: HeaderSubgrid.prototype.constructor,
 
     type: 'header',
 
     getRowCount: function() {
-        return this.grid.isShowHeaderRow() ? 1 : 0;
+        return this.grid.properties.showHeaderRow ? 1 : 0;
     },
 
     getValue: function(x, y) {
@@ -31,4 +46,4 @@ HeaderRow.prototype = {
     }
 };
 
-module.exports = HeaderRow;
+module.exports = HeaderSubgrid;

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -828,7 +828,7 @@ function propPrep(dataModel, columnIndex, propName, value) {
  * @private
  * @param {string} propName
  * @this DataSourceOrigin#
- * @returns {*[]}
+ * @returns {Array}
  */
 function getSchemaPropArr(propName, deprecatedMethodName) {
     this.deprecated(deprecatedMethodName, deprecatedMethodName + '() has been deprecated as of v1.2.0 and will be removed in a future release. Constructs like ' + deprecatedMethodName + '()[i] should be changed to schema[i]. (This deprecated method now returns a new array derived from schema.)');

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -431,7 +431,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @memberOf dataModels.JSON.prototype
      */
     setTopTotals: function(totalRows) {
-        return this.deprecate('setTopTotals(rows)', 'grid.behavior.setTopTotals(rows)', '1.1.0', arguments);
+        return this.deprecated('setTopTotals(rows)', 'grid.behavior.setTopTotals(rows)', '1.1.0', arguments);
     },
 
     /**
@@ -441,7 +441,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @memberOf dataModels.JSON.prototype
      */
     getTopTotals: function() {
-        return this.deprecate('getTopTotals(rows)', 'grid.behavior.getTopTotals(rows)', '1.1.0', arguments);
+        return this.deprecated('getTopTotals(rows)', 'grid.behavior.getTopTotals(rows)', '1.1.0', arguments);
     },
 
     /**
@@ -451,7 +451,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @memberOf dataModels.JSON.prototype
      */
     setBottomTotals: function(totalRows) {
-        return this.deprecate('setBottomTotals(rows)', 'grid.behavior.setBottomTotals(rows)', '1.1.0', arguments);
+        return this.deprecated('setBottomTotals(rows)', 'grid.behavior.setBottomTotals(rows)', '1.1.0', arguments);
     },
 
     /**
@@ -461,7 +461,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @memberOf dataModels.JSON.prototype
      */
     getBottomTotals: function() {
-        return this.deprecate('getBottomTotals(rows)', 'grid.behavior.getBottomTotals(rows)', '1.1.0', arguments);
+        return this.deprecated('getBottomTotals(rows)', 'grid.behavior.getBottomTotals(rows)', '1.1.0', arguments);
     },
 
     /**

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -45,6 +45,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     /**
      * Override to use a different origin.
      * @type(DataSourceBase}
+     * @memberOf dataModels.JSON.prototype
      */
     DataSourceOrigin: DataSourceOrigin,
 
@@ -97,6 +98,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     /**
      * @deprecated As of v1.0.7, reference the `dataSource` property instead.
      * @returns {*}
+     * @memberOf dataModels.JSON.prototype
      */
     getDataSource: function() {
         return this.deprecated('getDataSource()', 'dataSource', '1.0.7');
@@ -107,7 +109,8 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     /**
-     * @deprecated As of v1.1.0, use getIndexedData
+     * @deprecated As of v1.1.0, use `getIndexedData()` instead.
+     * @memberOf dataModels.JSON.prototype
      */
     getFilteredData: function() {
         return this.deprecated('getFilteredData()', 'getIndexedData()', '1.2.0', arguments);
@@ -141,7 +144,8 @@ var JSON = DataModel.extend('dataModels.JSON', {
 
     /**
      * @param {number} y - Data row coordinate.
-     * @returns {*}
+     * @returns {nunber} Row index in raw data array after dereferencing all data source indexing.
+     * @memberOf dataModels.JSON.prototype
      */
     getDataIndex: function(y) {
         return this.dataSource.getDataIndex(y);
@@ -327,6 +331,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * Find the last data source in the pipeline of specified type.
      * @param {string} type
      * @returns {DataSourceBase}
+     * @memberOf dataModels.JSON.prototype
      */
     findDataSourceByType: function(type) {
         var dataSource;
@@ -347,6 +352,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @returns {number|object} One of:
      * `type` specified - The number of updated data sources of the specified type.
      * `type` omitted - Hash containing the number of updated data sources by type.
+     * @memberOf dataModels.JSON.prototype
      */
     updateDataSources: function(type) {
         var results = {},
@@ -425,7 +431,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     /**
-     * @deprecated
+     * @deprecated As pf v1.1.0, use `this.grid.behavior.setTopTotals()` instead.
      * @summary Set the top total row(s).
      * @param {dataRowObject[]} totalRows - Array of 0 or more rows containing summary data. Omit to set to empty array.
      * @memberOf dataModels.JSON.prototype
@@ -435,7 +441,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     /**
-     * @deprecated
+     * @deprecated As pf v1.1.0, use `this.grid.behavior.getTopTotals()` instead.
      * @summary Get the top total row(s).
      * @returns {dataRowObject[]}
      * @memberOf dataModels.JSON.prototype
@@ -455,18 +461,18 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     /**
-     * @deprecated
      * @summary Get the bottom total row(s).
+     * @deprecated As pf v1.1.0, use `this.grid.behavior.getBottomTotals()` instead.
      * @returns {dataRowObject[]}
      * @memberOf dataModels.JSON.prototype
      */
     getBottomTotals: function() {
-        return this.deprecated('getBottomTotals(rows)', 'grid.behavior.getBottomTotals(rows)', '1.1.0', arguments);
+        return this.deprecated('getBottomTotals()', 'grid.behavior.getBottomTotals()', '1.1.0');
     },
 
     /**
      * @memberOf dataModels.JSON.prototype
-     * @returns {object[]}
+     * @returns {Column[]}
      */
     getActiveColumns: function() {
         return this.grid.behavior.columns.filter(function(column) {
@@ -475,8 +481,9 @@ var JSON = DataModel.extend('dataModels.JSON', {
     },
 
     /**
+     * @memberOf dataModels.JSON.prototype
      * @deprecated As of v1.0.6, use `this.getActiveColumns` instead.
-     * @returns {*}
+     * @returns {Column[]}
      */
     getVisibleColumns: function() {
         return this.deprecated('getVisibleColumns()', 'getActiveColumns()', '1.0.6', arguments);
@@ -622,6 +629,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * * A filter object - Turns the data source *ON*.
      * * `undefined` or `null` - Turns the data source *OFF.*
      * * A helper API. Turns the data source *ON*.
+     * @memberOf dataModels.JSON.prototype
      */
     registerHelperAPI: function(dataSourceType, helper) {
         this.api[dataSourceType] = helper = helper || nullDataSourceHelperAPI;
@@ -770,6 +778,8 @@ function reselectGridRowsBackedBySelectedDataRows() {
  * * When `property` is a hash and `value` is given: Unexpected; throws an error.
  *
  * @returns {propObject}
+ *
+ * @memberOf dataModels.JSON~
  */
 function propPrep(dataModel, columnIndex, propName, value) {
     var invalid,
@@ -829,6 +839,7 @@ function propPrep(dataModel, columnIndex, propName, value) {
  * @param {string} propName
  * @this DataSourceOrigin#
  * @returns {Array}
+ * @memberOf dataModels.JSON~
  */
 function getSchemaPropArr(propName, deprecatedMethodName) {
     this.deprecated(deprecatedMethodName, deprecatedMethodName + '() has been deprecated as of v1.2.0 and will be removed in a future release. Constructs like ' + deprecatedMethodName + '()[i] should be changed to schema[i]. (This deprecated method now returns a new array derived from schema.)');
@@ -838,6 +849,8 @@ function getSchemaPropArr(propName, deprecatedMethodName) {
 }
 
 /**
+ * Synonym of {@link JSON.prototype.reindex}.
+ * @name applyAnalytics
  * @deprecated
  * @memberOf dataModels.JSON.prototype
  */

--- a/src/dataModels/SummarySubgrid.js
+++ b/src/dataModels/SummarySubgrid.js
@@ -1,6 +1,13 @@
 'use strict';
 
-function SummaryRow(grid, options) {
+/**
+ * @implements dataModelAPI
+ * @param {Hypergrid} grid
+ * @param {object} [options]
+ * @param {string} [options.name]
+ * @constructor
+ */
+function SummarySubgrid(grid, options) {
     this.behavior = grid.behavior;
 
     /**
@@ -13,8 +20,8 @@ function SummaryRow(grid, options) {
     }
 }
 
-SummaryRow.prototype = {
-    constructor: SummaryRow.prototype.constructor,
+SummarySubgrid.prototype = {
+    constructor: SummarySubgrid.prototype.constructor,
 
     type: 'summary',
 
@@ -45,4 +52,4 @@ SummaryRow.prototype = {
     }
 };
 
-module.exports = SummaryRow;
+module.exports = SummarySubgrid;

--- a/src/dataModels/index.js
+++ b/src/dataModels/index.js
@@ -1,9 +1,54 @@
 'use strict';
 
-module.exports = {
-    DataModel: require('./DataModel'), // abstract base class
+/** @namespace src/dataModels */
+
+var dataModels = {
+    /**
+     * Abstract base class.
+     * @type {DataModel}
+     * @see {DataModel}
+     * @memberOf src/dataModels
+     */
+    DataModel: require('./DataModel'),
+
+    /**
+     * @see {@link dataModels.JSON}
+     * @implements dataModelAPI
+     * @memberOf src/dataModels
+     */
     JSON: require('./JSON'),
+
+    /**
+     * A single-row data model for the column headers.
+     * @see {@link HeaderSubgrid}
+     * @implements dataModelAPI
+     * @memberOf src/dataModels
+     */
     HeaderSubgrid: require('./HeaderSubgrid'),
+
+    /**
+     * A single-row data model for the filter cells.
+     * @see {@link FilterSubgrid}
+     * @implements dataModelAPI
+     * @memberOf src/dataModels
+     */
     FilterSubgrid: require('./FilterSubgrid'),
-    SummarySubgrid: require('./SummarySubgrid')
+
+    /**
+     * A multi-row data model for arbitrary summary data.
+     * @see {@link SummarySubgrid}
+     * @implements dataModelAPI
+     * @memberOf src/dataModels
+     */
+    SummarySubgrid: require('./SummarySubgrid'),
+
+    /**
+     * A single-row data model for  arbitrary summary data.
+     * @see {@link InfoSubgrid}
+     * @implements dataModelAPI
+     * @memberOf src/dataModels
+     */
+    InfoSubgrid: require('./InfoSubgrid')
 };
+
+module.exports = dataModels;

--- a/src/dialogs/Dialog.js
+++ b/src/dialogs/Dialog.js
@@ -90,8 +90,8 @@ var Dialog = Base.extend('Dialog', {
      * @param {HTMLElement} [container] - If undefined, dialog is appended to body.
      *
      * If defined, dialog is appended to container. When container is not body, it will be:
-     * # made visible before append (it should initially be hidden)
-     * # made hidden after remove
+     * 0. made visible before append (it should initially be hidden)
+     * 0. made hidden after remove
      */
     open: function(container) {
         var error;

--- a/src/jsdoc/external-types.js
+++ b/src/jsdoc/external-types.js
@@ -5,3 +5,6 @@
 /** @typedef Rectangle
  * @see http://openfin.github.io/rectangular/Rectangle.html
  */
+
+/** @typedef {object} dataRowObject
+ */

--- a/src/jsdoc/interfaces/dataModelAPI.js
+++ b/src/jsdoc/interfaces/dataModelAPI.js
@@ -1,0 +1,26 @@
+/**
+ * @interface dataModelAPI
+ * @summary Data model API.
+ * @desc Blah blah blah.
+ */
+
+/**
+ * @method
+ * @name dataModelAPI#getRowCount
+ * @returns {number} The number of data rows currently contained in the model.
+ */
+
+/**
+ * @method
+ * @name dataModelAPI#getRow
+ * @param {number} rowIndex
+ * @returns {number|undefined} The data row with the given `rowIndex`; or `undefined` if no such row.
+ */
+
+/**
+ * @method
+ * @name dataModelAPI#getValue
+ * @param {number} columnIndex
+ * @param {number} rowIndex
+ * @returns {string|number|boolean|null} The member with the given `columnIndex` from the data row with the given `rowIndex`.
+ */

--- a/src/jsdoc/interfaces/dataSourceHelperAPI.js
+++ b/src/jsdoc/interfaces/dataSourceHelperAPI.js
@@ -12,7 +12,7 @@
  * @method
  * @name dataSourceHelperAPI#test
  * @summary Tests data row for inclusion/exclusion from the grid display.
- * @desc Implementation of this method is required.
+ * @desc Implementation of this method is required only for filter data sources.
  * @param {object} dataRow
  * @returns {boolean} Truthy value means row "passes" the test, _i.e.,_ passes through the filter and should be included in the grid display.
  */

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -38,7 +38,7 @@ var visibleColumnPropertiesDescriptor = {
 /** @typedef {object} visibleRowDescriptor
  * @property {number} index - A back reference to the element's array index in {@link Renderer#visibleRows}.
  * @property {number} rowIndex - Local vertical row coordinate within the subgrid to which the row belongs, adjusted for scrolling.
- * @property {DataModel} subgrid - A reference to the subgrid to which the row belongs.
+ * @property {dataModelAPI} subgrid - A reference to the subgrid to which the row belongs.
  * @property {number} top - Pixel coordinate of the top edge of this row, rounded to nearest integer.
  * @property {number} bottom - Pixel coordinate of the bottom edge of this row, rounded to nearest integer.
  * @property {number} height - Height of this row in pixels, rounded to nearest integer.


### PR DESCRIPTION
The subgrids option is now serializable. That is, you can now give strings instead of a references to data models. The strings are registered data model names (in src/dataModels/index.js).

Like grid renderers, these data model names are case-sensitive. This is however a break from our other name registries, such as cell renderers and cell editors. We clearly should be consistent, but rather than following suit, I'm thinking of making cell renderers and cell editors case-sensitive as well because its simpler, less code, more performant (cell renderers require a .toLowerCase() call on every cell on every render), and not too much to ask from developers who are after all already familiar with case-senstive identifers in Javascript. The only reason SWirts made them case insensitive was that as data in a datagram it seemed safer. Thoughts?

This is part of GRID-373, our drive towards putting all critical set-up data in a serializable state datagram that can be used in a setState call, or passed to a Hypergrid constructor.

