### PR TITLE
GRID-457: Prevent filter cell errors

### DIFF
--- a/src/cellEditors/FilterBox.js
+++ b/src/cellEditors/FilterBox.js
@@ -158,7 +158,11 @@ var FilterBox = ComboBox.extend('FilterBox', {
             !CellEditor.prototype.keyup.call(this, event) &&
             this.grid.properties.filteringMode === 'immediate'
         ) {
-            this.saveEditorValue(this.getEditorValue());
+            try {
+                this.saveEditorValue(this.getEditorValue());
+            } catch (err) {
+                // ignore syntax errors in immediate mode
+            }
         }
     },
 


### PR DESCRIPTION
Fixes the issue simply by ignoring syntax errors in immediate mode (until editing stopped).