### PR TITLE
GRID-484: Hypergrid reset regression - listeners

### DIFF
--- a/add-ons/dialog-ui/index.js
+++ b/add-ons/dialog-ui/index.js
@@ -14,7 +14,7 @@ function DialogUI(grid, targets) {
     mixInTo('Hypergrid', grid, require('./mix-ins/grid'));
     mixInTo('Behavior', grid.behavior, require('./mix-ins/behavior'));
 
-    this.grid.addEventListener('fin-external-ui-on', function(keys){
+    this.grid.addEventListener('fin-external-ui-on', true, function(keys){
         grid.toggleDialog('ColumnPicker');
     });
 

--- a/add-ons/hyper-sorter/index.js
+++ b/add-ons/hyper-sorter/index.js
@@ -12,7 +12,7 @@ function Hypersorter(grid, targets) {
         DESC: '\u25bc' // DOWNWARDS_BLACK_ARROW, aka '▼'
     });
 
-    grid.addEventListener('fin-column-sort', function(c, keys){
+    grid.addEventListener('fin-column-sort', true, function(c, keys){
         grid.toggleSort(c, keys);
     });
 }

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -201,6 +201,11 @@ window.onload = function() {
         behavior.reindex();
     }
 
+    function reset() {
+        grid.reset();
+        addEventListeners();
+    }
+
     // Preset a default dialog options object. Used by call to toggleDialog('ColumnPicker') from features/ExternalUI.js and by toggleDialog() defined herein.
     // Dependent on column picker example add-on
     grid.setDialogOptions({
@@ -216,7 +221,7 @@ window.onload = function() {
         { label: 'Set Data 1 (5000 rows)', onclick: function() { setData(people1); } },
         { label: 'Set Data 2 (10000 rows)', onclick: function() { setData(people2); } },
         { label: 'Set Data 3 (tree data)', onclick: function() { setData(treeData); } },
-        { label: 'Reset Grid', onclick: function() { grid.reset(); } },
+        { label: 'Reset Grid', onclick: reset },
         { label: 'Toggle all drill-downs', onclick: toggleAllCtrlGroups }
 
     ].forEach(function(item) {
@@ -684,222 +689,225 @@ window.onload = function() {
         return cellEditor;
     };
 
-    grid.addEventListener('fin-click', function(e) {
-        var cell = e.detail.gridCell;
-        if (vent) { console.log('fin-click cell:', cell); }
-    });
-
-    grid.addEventListener('fin-double-click', function(e) {
-        var cell = e.detail.gridCell;
-        var rowContext = e.detail.dataRow;
-        if (vent) { console.log('fin-double-click row-context:', rowContext); }
-    });
-
-    grid.addEventListener('fin-button-pressed', function(e) {
-        var cellEvent = e.detail;
-        cellEvent.value = !cellEvent.value;
-    });
-
-    grid.addEventListener('fin-scroll-x', function(e) {
-        if (vent) { console.log('fin-scroll-x ', e.detail.value); }
-    });
-
-    grid.addEventListener('fin-scroll-y', function(e) {
-        if (vent) { console.log('fin-scroll-y', e.detail.value); }
-    });
-
     grid.addProperties({
         readOnly: false
     });
 
-    grid.addEventListener('fin-cell-enter', function(e) {
-        var cellEvent = e.detail;
+    addEventListeners();
 
-        //if (vent) { console.log('fin-cell-enter', cell.x, cell.y); }
-
-        //how to set the tooltip....
-        grid.setAttribute('title', 'event name: "fin-cell-enter"\n' +
-            'gridCell: { x: ' + cellEvent.gridCell.x + ', y: ' + cellEvent.gridCell.y + ' }\n' +
-            'dataCell: { x: ' + cellEvent.dataCell.x + ', y: ' + cellEvent.dataCell.y + ' }\n' +
-            'subgrid type: "' + cellEvent.subgrid.type + '"\n' +
-            'subgrid name: ' + (cellEvent.subgrid.name ? '"' + cellEvent.subgrid.name + '"' : 'undefined')
-        );
-    });
-
-    grid.addEventListener('fin-set-totals-value', function(e) {
-        var detail = e.detail,
-            areas = detail.areas || ['top', 'bottom'];
-
-        areas.forEach(function(area) {
-            var methodName = 'get' + area[0].toUpperCase() + area.substr(1) + 'Totals',
-                totalsRow = dataModel[methodName]();
-
-            totalsRow[detail.y][detail.x] = detail.value;
+    function addEventListeners() {
+        grid.addEventListener('fin-click', function(e) {
+            var cell = e.detail.gridCell;
+            if (vent) { console.log('fin-click cell:', cell); }
         });
 
-        grid.repaint();
-    });
+        grid.addEventListener('fin-double-click', function(e) {
+            var rowContext = e.detail.dataRow;
+            if (vent) { console.log('fin-double-click row-context:', rowContext); }
+        });
 
-    grid.addEventListener('fin-filter-applied', function(e) {
-        if (vent) { console.log('fin-filter-applied', e); }
-    });
+        grid.addEventListener('fin-button-pressed', function(e) {
+            var cellEvent = e.detail;
+            cellEvent.value = !cellEvent.value;
+        });
 
-    /**
-     * @summary Listen for certain key presses from grid or cell editor.
-     * @desc NOTE: fincanvas's internal char map yields mixed case while fin-editor-key* events do not.
-     * @return {boolean} Not handled.
-     */
-    function handleCursorKey(e) {
-        var detail = e.detail,
-            key = String.fromCharCode(detail.key).toUpperCase(),
-            result = false; // means event handled herein
+        grid.addEventListener('fin-scroll-x', function(e) {
+            if (vent) { console.log('fin-scroll-x ', e.detail.value); }
+        });
 
-        if (detail.input instanceof grid.cellEditors.editors.filterbox) { // or: detail.input.$$CLASS_NAME === 'FilterBox'
-            // skip "select" calls if editing a filter cell
-        } else if (detail.ctrl) {
-            if (detail.shift) {
-                switch (key) {
-                    case '0': if (grid.stopEditing()) { grid.selectToViewportCell(0, 0); } break;
-                    case '9': if (grid.stopEditing()) { grid.selectToFinalCell(); } break;
-                    case '8': if (grid.stopEditing()) { grid.selectToFinalCellOfCurrentRow(); } break;
-                    case '7': if (grid.stopEditing()) { grid.selectToFirstCellOfCurrentRow(); } break;
-                    default: result = true;
-                }
-            } else {
-                switch (key) {
-                    case '0': if (grid.stopEditing()) { grid.selectViewportCell(0, 0); } break;
-                    case '9': if (grid.stopEditing()) { grid.selectFinalCell(); } break;
-                    case '8': if (grid.stopEditing()) { grid.selectFinalCellOfCurrentRow(); } break;
-                    case '7': if (grid.stopEditing()) { grid.selectFirstCellOfCurrentRow(); } break;
-                    default: result = true;
+        grid.addEventListener('fin-scroll-y', function(e) {
+            if (vent) { console.log('fin-scroll-y', e.detail.value); }
+        });
+
+        grid.addEventListener('fin-cell-enter', function(e) {
+            var cellEvent = e.detail;
+
+            //if (vent) { console.log('fin-cell-enter', cell.x, cell.y); }
+
+            //how to set the tooltip....
+            grid.setAttribute('title', 'event name: "fin-cell-enter"\n' +
+                'gridCell: { x: ' + cellEvent.gridCell.x + ', y: ' + cellEvent.gridCell.y + ' }\n' +
+                'dataCell: { x: ' + cellEvent.dataCell.x + ', y: ' + cellEvent.dataCell.y + ' }\n' +
+                'subgrid type: "' + cellEvent.subgrid.type + '"\n' +
+                'subgrid name: ' + (cellEvent.subgrid.name ? '"' + cellEvent.subgrid.name + '"' : 'undefined')
+            );
+        });
+
+        grid.addEventListener('fin-set-totals-value', function(e) {
+            var detail = e.detail,
+                areas = detail.areas || ['top', 'bottom'];
+
+            areas.forEach(function(area) {
+                var methodName = 'get' + area[0].toUpperCase() + area.substr(1) + 'Totals',
+                    totalsRow = dataModel[methodName]();
+
+                totalsRow[detail.y][detail.x] = detail.value;
+            });
+
+            grid.repaint();
+        });
+
+        grid.addEventListener('fin-filter-applied', function(e) {
+            if (vent) { console.log('fin-filter-applied', e); }
+        });
+
+        /**
+         * @summary Listen for certain key presses from grid or cell editor.
+         * @desc NOTE: fincanvas's internal char map yields mixed case while fin-editor-key* events do not.
+         * @return {boolean} Not handled.
+         */
+        function handleCursorKey(e) {
+            var detail = e.detail,
+                key = String.fromCharCode(detail.key).toUpperCase(),
+                result = false; // means event handled herein
+
+            if (detail.input instanceof grid.cellEditors.editors.filterbox) { // or: detail.input.$$CLASS_NAME === 'FilterBox'
+                // skip "select" calls if editing a filter cell
+            } else if (detail.ctrl) {
+                if (detail.shift) {
+                    switch (key) {
+                        case '0': if (grid.stopEditing()) { grid.selectToViewportCell(0, 0); } break;
+                        case '9': if (grid.stopEditing()) { grid.selectToFinalCell(); } break;
+                        case '8': if (grid.stopEditing()) { grid.selectToFinalCellOfCurrentRow(); } break;
+                        case '7': if (grid.stopEditing()) { grid.selectToFirstCellOfCurrentRow(); } break;
+                        default: result = true;
+                    }
+                } else {
+                    switch (key) {
+                        case '0': if (grid.stopEditing()) { grid.selectViewportCell(0, 0); } break;
+                        case '9': if (grid.stopEditing()) { grid.selectFinalCell(); } break;
+                        case '8': if (grid.stopEditing()) { grid.selectFinalCellOfCurrentRow(); } break;
+                        case '7': if (grid.stopEditing()) { grid.selectFirstCellOfCurrentRow(); } break;
+                        default: result = true;
+                    }
                 }
             }
+
+            return result;
         }
 
-        return result;
+        grid.addEventListener('fin-keydown', handleCursorKey);
+
+        grid.addEventListener('fin-editor-keydown', function(e) {
+            // var detail = e.detail,
+            //     ke = detail.keyEvent;
+            //
+            // // more detail, please
+            // detail.primitiveEvent = ke;
+            // detail.key = ke.keyCode;
+            // detail.shift = ke.shiftKey;
+            //
+            // handleCursorKey(e);
+        });
+
+
+        grid.addEventListener('fin-selection-changed', function(e) {
+
+            if (vent) {
+                console.log('fin-selection-changed', grid.getSelectedRows(), grid.getSelectedColumns(), grid.getSelections());
+            }
+
+            if (e.detail.selections.length === 0) {
+                console.log('no selections');
+                return;
+            }
+
+            // to get the selected rows uncomment the below.....
+            // console.log(grid.getRowSelectionMatrix());
+            // console.log(grid.getRowSelection());
+
+        });
+
+        grid.addEventListener('fin-row-selection-changed', function(e) {
+            var detail = e.detail;
+
+            if (vent) { console.log('fin-row-selection-changed', detail); }
+
+            // Move cell selection with row selection
+            var rows = detail.rows,
+                selections = detail.selections;
+            if (
+                grid.properties.singleRowSelectionMode && // let's only attempt this when in this mode
+                !grid.properties.multipleSelections && // and only when in single selection mode
+                rows.length && // user just selected a row (must be single row due to mode we're in)
+                selections.length  // there was a cell region selected (must be the only one)
+            ) {
+                var rect = grid.selectionModel.getLastSelection(), // the only cell selection
+                    x = rect.left,
+                    y = rows[0], // we know there's only 1 row selected
+                    width = rect.right - x,
+                    height = 0, // collapse the new region to occupy a single row
+                    fireSelectionChangedEvent = false;
+
+                grid.selectionModel.select(x, y, width, height, fireSelectionChangedEvent);
+                grid.repaint();
+            }
+
+            if (rows.length === 0) {
+                console.log('no rows selected');
+                return;
+            }
+            //we have a function call to create the selection matrix because
+            //we don't want to create alot of needless garbage if the user
+            //is just navigating around
+            console.log(grid.getRowSelectionMatrix());
+            console.log(grid.getRowSelection());
+        });
+
+        grid.addEventListener('fin-column-selection-changed', function(e) {
+            if (vent) { console.log('fin-column-selection-changed', e.detail); }
+
+            if (e.detail.columns.length === 0) {
+                console.log('no rows selected');
+                return;
+            }
+            //we have a function call to create the selection matrix because
+            //we don't want to create alot of needless garbage if the user
+            //is just navigating around
+            console.log(grid.getColumnSelectionMatrix());
+            console.log(grid.getColumnSelection());
+        });
+
+        grid.addEventListener('fin-editor-data-change', function(e) {
+            if (vent) { console.log('fin-editor-data-change', e.detail); }
+
+        });
+
+        grid.addEventListener('fin-request-cell-edit', function(e) {
+            if (vent) { console.log('fin-request-cell-edit', e); }
+            //e.preventDefault(); //uncomment to cancel editor popping up
+        });
+
+        grid.addEventListener('fin-before-cell-edit', function(e) {
+            if (vent) { console.log('fin-before-cell-edit', e); }
+            //e.preventDefault(); //uncomment to cancel updating the model with the new data
+        });
+
+        grid.addEventListener('fin-after-cell-edit', function(e) {
+            if (vent) { console.log('fin-after-cell-edit', e); }
+        });
+
+        grid.addEventListener('fin-editor-keyup', function(e) {
+            if (vent) { console.log('fin-editor-keyup', e.detail); }
+        });
+
+        grid.addEventListener('fin-editor-keypress', function(e) {
+            if (vent) { console.log('fin-editor-keypress', e.detail); }
+        });
+
+        grid.addEventListener('fin-editor-keydown', function(e) {
+            if (vent) { console.log('fin-editor-keydown', e.detail); }
+        });
+
+        grid.addEventListener('fin-groups-changed', function(e) {
+            if (vent) { console.log('fin-groups-changed', e.detail); }
+        });
+
+        grid.addEventListener('fin-context-menu', function(e) {
+            var modelPoint = e.detail.gridCell;
+            if (vent) { console.log('fin-context-menu(' + modelPoint.x + ', ' + modelPoint.y + ')'); }
+        });
     }
-
-    grid.addEventListener('fin-keydown', handleCursorKey);
-
-    grid.addEventListener('fin-editor-keydown', function(e) {
-        // var detail = e.detail,
-        //     ke = detail.keyEvent;
-        //
-        // // more detail, please
-        // detail.primitiveEvent = ke;
-        // detail.key = ke.keyCode;
-        // detail.shift = ke.shiftKey;
-        //
-        // handleCursorKey(e);
-    });
-
-
-    grid.addEventListener('fin-selection-changed', function(e) {
-
-        if (vent) {
-            console.log('fin-selection-changed', grid.getSelectedRows(), grid.getSelectedColumns(), grid.getSelections());
-        }
-
-        if (e.detail.selections.length === 0) {
-            console.log('no selections');
-            return;
-        }
-
-        // to get the selected rows uncomment the below.....
-        // console.log(grid.getRowSelectionMatrix());
-        // console.log(grid.getRowSelection());
-
-    });
-
-    grid.addEventListener('fin-row-selection-changed', function(e) {
-        var detail = e.detail;
-
-        if (vent) { console.log('fin-row-selection-changed', detail); }
-
-        // Move cell selection with row selection
-        var rows = detail.rows,
-            selections = detail.selections;
-        if (
-            grid.properties.singleRowSelectionMode && // let's only attempt this when in this mode
-            !grid.properties.multipleSelections && // and only when in single selection mode
-            rows.length && // user just selected a row (must be single row due to mode we're in)
-            selections.length  // there was a cell region selected (must be the only one)
-        ) {
-            var rect = grid.selectionModel.getLastSelection(), // the only cell selection
-                x = rect.left,
-                y = rows[0], // we know there's only 1 row selected
-                width = rect.right - x,
-                height = 0, // collapse the new region to occupy a single row
-                fireSelectionChangedEvent = false;
-
-            grid.selectionModel.select(x, y, width, height, fireSelectionChangedEvent);
-            grid.repaint();
-        }
-
-        if (rows.length === 0) {
-            console.log('no rows selected');
-            return;
-        }
-        //we have a function call to create the selection matrix because
-        //we don't want to create alot of needless garbage if the user
-        //is just navigating around
-        console.log(grid.getRowSelectionMatrix());
-        console.log(grid.getRowSelection());
-    });
-
-    grid.addEventListener('fin-column-selection-changed', function(e) {
-        if (vent) { console.log('fin-column-selection-changed', e.detail); }
-
-        if (e.detail.columns.length === 0) {
-            console.log('no rows selected');
-            return;
-        }
-        //we have a function call to create the selection matrix because
-        //we don't want to create alot of needless garbage if the user
-        //is just navigating around
-        console.log(grid.getColumnSelectionMatrix());
-        console.log(grid.getColumnSelection());
-    });
-
-    grid.addEventListener('fin-editor-data-change', function(e) {
-        if (vent) { console.log('fin-editor-data-change', e.detail); }
-
-    });
-
-    grid.addEventListener('fin-request-cell-edit', function(e) {
-        if (vent) { console.log('fin-request-cell-edit', e); }
-        //e.preventDefault(); //uncomment to cancel editor popping up
-    });
-
-    grid.addEventListener('fin-before-cell-edit', function(e) {
-        if (vent) { console.log('fin-before-cell-edit', e); }
-        //e.preventDefault(); //uncomment to cancel updating the model with the new data
-    });
-
-    grid.addEventListener('fin-after-cell-edit', function(e) {
-        if (vent) { console.log('fin-after-cell-edit', e); }
-    });
-
-    grid.addEventListener('fin-editor-keyup', function(e) {
-        if (vent) { console.log('fin-editor-keyup', e.detail); }
-    });
-
-    grid.addEventListener('fin-editor-keypress', function(e) {
-        if (vent) { console.log('fin-editor-keypress', e.detail); }
-    });
-
-    grid.addEventListener('fin-editor-keydown', function(e) {
-        if (vent) { console.log('fin-editor-keydown', e.detail); }
-    });
-
-    grid.addEventListener('fin-groups-changed', function(e) {
-        if (vent) { console.log('fin-groups-changed', e.detail); }
-    });
-
-    grid.addEventListener('fin-context-menu', function(e) {
-        var modelPoint = e.detail.gridCell;
-        if (vent) { console.log('fin-context-menu(' + modelPoint.x + ', ' + modelPoint.y + ')'); }
-    });
 
     // make buttons div absolute so buttons width of 100% doesn't stretch to width of dashboard
     ctrlGroups.style.top = ctrlGroups.getBoundingClientRect().top + 'px';

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -11,17 +11,22 @@ module.exports = {
     /**
      * @summary Add an event listener to me.
      * @param {string} eventName - The type of event we are interested in.
-     * @param {function} listener - The event handler.
      * @param {boolean} [internal=false] - Internal listeners can be removed as usual by {@link Hypergrid#removeEventListener|grid.removeEventListener}. However, they are ignored by {@link Hypergrid#removeAllEventListeners|grid.removeAllEventListeners} (called on {@link Hypergrid#reset|reset}).
+     * @param {function} listener - The event handler.
      * @memberOf Hypergrid#
      */
-    addEventListener: function(eventName, listener, internal) {
+    addEventListener: function(eventName, internal, listener) {
+        if (arguments.length === 2) {
+            listener = internal;
+            internal = false;
+        }
+
         var self = this,
             listeners = this.listeners[eventName] = this.listeners[eventName] || [],
-            info = listeners.find(function(info) { return info.listener === listener; });
+            alreadyAttached = listeners.find(function(info) { return info.listener === listener; });
 
-        if (!info) {
-            info = {
+        if (!alreadyAttached) {
+            var info = {
                 internal: internal,
                 listener: listener,
                 decorator: function(e) {
@@ -341,12 +346,12 @@ module.exports = {
             }
         }
 
-        this.addEventListener('fin-canvas-resized', function(e) {
+        this.addEventListener('fin-canvas-resized', true, function(e) {
             self.resized();
             self.fireSyntheticGridResizedEvent(e);
         });
 
-        this.addEventListener('fin-canvas-mousemove', function(e) {
+        this.addEventListener('fin-canvas-mousemove', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -356,7 +361,7 @@ module.exports = {
             });
         });
 
-        this.addEventListener('fin-canvas-mousedown', function(e) {
+        this.addEventListener('fin-canvas-mousedown', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -374,7 +379,7 @@ module.exports = {
             });
         });
 
-        this.addEventListener('fin-canvas-click', function(e) {
+        this.addEventListener('fin-canvas-click', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -385,7 +390,7 @@ module.exports = {
             });
         });
 
-        this.addEventListener('fin-canvas-mouseup', function(e) {
+        this.addEventListener('fin-canvas-mouseup', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -406,7 +411,7 @@ module.exports = {
             });
         });
 
-        this.addEventListener('fin-canvas-dblclick', function(e) {
+        this.addEventListener('fin-canvas-dblclick', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -416,7 +421,7 @@ module.exports = {
             });
         });
 
-        this.addEventListener('fin-canvas-drag', function(e) {
+        this.addEventListener('fin-canvas-drag', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -424,7 +429,7 @@ module.exports = {
             handleMouseEvent(e, self.delegateMouseDrag);
         });
 
-        this.addEventListener('fin-canvas-keydown', function(e) {
+        this.addEventListener('fin-canvas-keydown', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -432,7 +437,7 @@ module.exports = {
             self.delegateKeyDown(e);
         });
 
-        this.addEventListener('fin-canvas-keyup', function(e) {
+        this.addEventListener('fin-canvas-keyup', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
@@ -440,18 +445,18 @@ module.exports = {
             self.delegateKeyUp(e);
         });
 
-        this.addEventListener('fin-canvas-wheelmoved', function(e) {
+        this.addEventListener('fin-canvas-wheelmoved', true, function(e) {
             handleMouseEvent(e, self.delegateWheelMoved);
         });
 
-        this.addEventListener('fin-canvas-mouseout', function(e) {
+        this.addEventListener('fin-canvas-mouseout', true, function(e) {
             if (self.properties.readOnly) {
                 return;
             }
             handleMouseEvent(e, self.delegateMouseExit);
         });
 
-        this.addEventListener('fin-canvas-context-menu', function(e) {
+        this.addEventListener('fin-canvas-context-menu', true, function(e) {
             handleMouseEvent(e, function(mouseEvent){
                 self.delegateContextMenu(mouseEvent);
                 self.fireSyntheticContextMenuEvent(mouseEvent);


### PR DESCRIPTION
`grid.reset()` calls `grid.removeAllEventListeners()`.

`grid.removeAllEventListeners()` goes through the list of added listeners and removes all that are not marked internal.

Unfortunately, I had forgotten to mark the internal event listeners as such so they were being removed. This PR fixes that: I added `true` as the (optional) second parameter to these `grid.addEventListener()` calls.

For the event listeners added by the demo (application level), I demonstrate another approach: Instead of marking them as internal, I re-add them after reset.

@Dwaynekj The internal event listeners I marked were all in events.js and were all listening for "fin-canvas" events, so this will of course conflict with your edits in your fin-canvas event PR...