### PR TITLE
GRID-483: Edit on keyboard navigation to any cell

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -901,8 +901,12 @@ var defaults = {
     editOnKeydown: true,
 
     /**
-     * Grid-level property.
-     * When user navigates away from a cell editor (by pressing a nav key as defined in {@link module:defaults.navKeyMap}), open the cell editor of the destination cell.
+     * @summary Open cell editor when cell selected via keyboard navigation.
+     * @desc Keyboard navigation always includes:
+     * 1. The four arrow keys -- but only when there is no active text cell editor open
+     * 2. Additional keys mapped to the four directs in {@link module:defaults.navKeyMap}
+     *
+     * Generally set at the grid level. If set at the column (or cell) level, note that the property pertains to the cell navigated _to,_ not the cell navigated _away from._
      * @default
      * @type {boolean}
      * @memberOf module:defaults

--- a/src/features/CellSelection.js
+++ b/src/features/CellSelection.js
@@ -107,10 +107,10 @@ var CellSelection = Feature.extend('CellSelection', {
         if (handler) {
             handler.call(this, grid, detail);
 
-            // STEP 2: Open the cell editor if `editOnNextCell`, `editable` and `editor` props are all set
-            if (detail.editor && grid.properties.editOnNextCell) {
-                cellEvent = grid.getGridCellFromLastSelection();
-                grid.editAt(cellEvent);
+            // STEP 2: Open the cell editor at the new position if it has `editOnNextCell` and is `editable`
+            cellEvent = grid.getGridCellFromLastSelection(); // new cell
+            if (cellEvent.properties.editOnNextCell) {
+                grid.editAt(cellEvent); // succeeds only if `editable`
             }
 
             // STEP 3: If editor not opened on new cell, take focus


### PR DESCRIPTION
1. No longer checks to see if cell navigated away from had open editor

2. Now checks the prop on the cell navigated to rather than the cell navigated away from