### PR TITLE
GRID-484: Hypergrid reset regression

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -314,7 +314,7 @@ var Hypergrid = Base.extend('Hypergrid', {
         this.removeAllEventListeners();
 
         this.lastEdgeSelection = [0, 0];
-        this.selectionModel = new SelectionModel(this);
+        this.selectionModel.reset();
         this.renderOverridesCache = {};
         this.clearMouseDown();
         this.dragExtent = new Point(0, 0);
@@ -568,9 +568,6 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @param {object} properties - An object of various key value pairs.
      */
     refreshProperties: function() {
-        var state = this.properties;
-        this.selectionModel.multipleSelections = state.multipleSelections;
-
         this.computeCellsBounds();
         this.checkScrollbarVisibility();
         this.behavior.defaultRowHeight = null;

--- a/src/lib/SelectionModel.js
+++ b/src/lib/SelectionModel.js
@@ -9,63 +9,8 @@ var RangeSelectionModel = require('sparse-boolean-array');
  */
 
 function SelectionModel(grid) {
-
     this.grid = grid;
-
-    /**
-     * @name multipleSelections
-     * @type {boolean}
-     * @summary Can select multiple cell regions.
-     * @memberOf SelectionModel.prototype
-     */
-    this.multipleSelections = grid.properties.multipleSelections;
-
-    /**
-     * @name selections
-     * @type {Rectangle[]}
-     * @summary The selection rectangles.
-     * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
-     * @memberOf SelectionModel.prototype
-     */
-    this.selections = [];
-
-    /**
-     * @name flattenedX
-     * @type {Rectangle[]}
-     * @summary The selection rectangles flattened in the horizontal direction (no width).
-     * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
-     * @memberOf SelectionModel.prototype
-     */
-    this.flattenedX = [];
-
-    /**
-     * @name flattenedY
-     * @type {Rectangle[]}
-     * @summary The selection rectangles flattened in the vertical direction (no height).
-     * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
-     * @memberOf SelectionModel.prototype
-     */
-    this.flattenedY = [];
-
-    /**
-     * @name rowSelectionModel
-     * @type {RangeSelectionModel}
-     * @summary The selection rectangles.
-     * @desc Created as a new RangeSelectionModel upon instantiation by the {@link SelectionModel|constructor}.
-     * @memberOf SelectionModel.prototype
-     */
-    this.rowSelectionModel = new RangeSelectionModel();
-
-    /**
-     * @name columnSelectionModel
-     * @type {RangeSelectionModel}
-     * @summary The selection rectangles.
-     * @desc Created as a new RangeSelectionModel upon instantiation by the {@link SelectionModel|constructor}.
-     * @memberOf SelectionModel.prototype
-     */
-    this.columnSelectionModel = new RangeSelectionModel();
-
-    this.setLastSelectionType('');
+    this.reset();
 }
 
 SelectionModel.prototype = {
@@ -77,6 +22,55 @@ SelectionModel.prototype = {
      * @memberOf SelectionModel.prototype
      */
     allRowsSelected: false,
+
+    reset: function() {
+        /**
+         * @name selections
+         * @type {Rectangle[]}
+         * @summary The selection rectangles.
+         * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
+         * @memberOf SelectionModel.prototype
+         */
+        this.selections = [];
+
+        /**
+         * @name flattenedX
+         * @type {Rectangle[]}
+         * @summary The selection rectangles flattened in the horizontal direction (no width).
+         * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
+         * @memberOf SelectionModel.prototype
+         */
+        this.flattenedX = [];
+
+        /**
+         * @name flattenedY
+         * @type {Rectangle[]}
+         * @summary The selection rectangles flattened in the vertical direction (no height).
+         * @desc Created as an empty array upon instantiation by the {@link SelectionModel|constructor}.
+         * @memberOf SelectionModel.prototype
+         */
+        this.flattenedY = [];
+
+        /**
+         * @name rowSelectionModel
+         * @type {RangeSelectionModel}
+         * @summary The selection rectangles.
+         * @desc Created as a new RangeSelectionModel upon instantiation by the {@link SelectionModel|constructor}.
+         * @memberOf SelectionModel.prototype
+         */
+        this.rowSelectionModel = new RangeSelectionModel();
+
+        /**
+         * @name columnSelectionModel
+         * @type {RangeSelectionModel}
+         * @summary The selection rectangles.
+         * @desc Created as a new RangeSelectionModel upon instantiation by the {@link SelectionModel|constructor}.
+         * @memberOf SelectionModel.prototype
+         */
+        this.columnSelectionModel = new RangeSelectionModel();
+
+        this.setLastSelectionType('');
+    },
 
     /**
      * @memberOf SelectionModel.prototype
@@ -127,7 +121,7 @@ SelectionModel.prototype = {
             ? newSelection.corner
             : newSelection.origin;
 
-        if (this.multipleSelections) {
+        if (this.grid.properties.multipleSelections) {
             this.selections.push(newSelection);
             this.flattenedX.push(newSelection.flattenXAt(0));
             this.flattenedY.push(newSelection.flattenYAt(0));


### PR DESCRIPTION
This additional PR for this ticket resets the selection model on hypergrid reset rather than recreating it, thus letting existing references remain valid.