### PR TITLE
GRID-471: Cell selection after filter cell

### DIFF
--- a/src/features/Filters.js
+++ b/src/features/Filters.js
@@ -29,7 +29,7 @@ var Filters = Feature.extend('Filters', {
         }
 
         if (handler) {
-            handler(grid, detail);
+            handler.call(this, grid, detail);
         } else if (this.next) {
             this.next.handleKeyDown(grid, event);
         }
@@ -86,7 +86,8 @@ function moveDown(grid, detail) {
         gridX = cellEvent.visibleColumn.columnIndex;
 
     // Select first visible grid cell of this column
-    grid.selectCell(gridX, 0, true);
+    grid.selectViewportCell(gridX, 0);
+    grid.takeFocus();
 }
 
 module.exports = Filters;


### PR DESCRIPTION
This additional PR for this ticket fixes keyboard navigation after having closed a filter cell with RETURN key. The problem was the line of code that selected the cell (the top visible cell of the column) was making the wrong "select" call.