### PR TITLE
GRID-461: Icon functions

### DIFF
--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -66,8 +66,8 @@ function Column(behavior, indexOrOptions) {
     switch (index) {
         case -1:
             // Width of icon + 3-pixel spacer (checked and unchecked should be same width)
-            this.properties.minimumColumnWidth = (images.unchecked && images.unchecked.width)
-                ?  images.unchecked.width + 3 : 0;
+            var icon = images[Object.create(this.properties.rowHeader, { isDataRow: { value: true } }).leftIcon];
+            this.properties.minimumColumnWidth = icon ? icon.width + 3 : 0;
             break;
         case -2:
             // This case avoids the "out of range" error.

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -154,6 +154,19 @@ createColumnProperties.rowHeaderDescriptors = {
         set: function(value) {
             this.rowHeaderBackgroundSelectionColor = value;
         }
+    },
+    leftIcon: {
+        configurable: true,
+        enumerable: true,
+        get: function() {
+            var result;
+            if (this.isDataRow) {
+                result = this.isRowSelected ? 'checked' : 'unchecked';
+            } else if (this.isHeaderRow) {
+                result = this.allRowsSelected ? 'checked' : 'unchecked';
+            }
+            return result;
+        }
     }
 };
 

--- a/src/cellRenderers/SimpleCell.js
+++ b/src/cellRenderers/SimpleCell.js
@@ -47,21 +47,15 @@ var SimpleCell = CellRenderer.extend('SimpleCell', {
                 val = null;
             }
         } else if (config.isFilterRow) {
-            if (config.filterable) {
-                rightIcon = images[config.isHandleColumn || !val.length ? 'filter-off' : 'filter-on'];
-                config.renderFalsy = false;
+            if (config.isHandleColumn) {
+                leftIcon = images['filter-off'];
+            } else if (config.filterable) {
+                rightIcon = images[val.length ? 'filter-on' : 'filter-off'];
             }
-        } else if (!config.isHandleColumn) {
+        } else {
             leftIcon = images[config.leftIcon];
             centerIcon = images[config.centerIcon];
             rightIcon = images[config.rightIcon];
-        } else if (config.isDataRow) {
-            leftIcon = images[config.leftIcon != undefined ? config.leftIcon : config.isRowSelected ? 'checked' : 'unchecked']; // eslint-disable-line eqeqeq
-        } else if (config.isHeaderRow) {
-            leftIcon = images[config.leftIcon != undefined ? config.leftIcon : config.allRowsSelected ? 'checked' : 'unchecked']; // eslint-disable-line eqeqeq
-        } else {
-            // row handles for "summary" or other subgrids' rows: empty
-            val = '';
         }
 
         // Note: vf == 0 is fastest equivalent of vf === 0 || vf === false which excludes NaN, null, undefined

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -682,7 +682,10 @@ var defaults = {
     },
 
     /**
-     * This function is referenced here so it will be available to the cell renderers.
+     * @summary Execute value if "calculator" (function) or if column has calculator.
+     * @desc This function is referenced here so:
+     * 1. it will be available to the cell renderers.
+     * 2. Its context will naturally be the `config` object
      * @default {@link module:defaults.exec|exec}
      * @type {function}
      * @memberOf module:defaults


### PR DESCRIPTION
This makes it easy to delete or override the row handle `leftIcon` logic, or move it in its entirety to `centerIcon` or `rightIcon`, which answers the concern in the ticket.

See the updated [**_Icons_** wiki page](https://github.com/openfin/fin-hypergrid/wiki/Icons) for examples.