### PR TITLE
GRID-461: Icon functions, part 2

### DIFF
--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -164,8 +164,19 @@ createColumnProperties.rowHeaderDescriptors = {
                 result = this.isRowSelected ? 'checked' : 'unchecked';
             } else if (this.isHeaderRow) {
                 result = this.allRowsSelected ? 'checked' : 'unchecked';
+            } else if (this.isFilterRow) {
+                result = 'filter-off';
             }
             return result;
+        },
+        set: function(value) {
+            // replace self with a simple instance var
+            Object.defineProperty(this, 'leftIcon', {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                value: value
+            });
         }
     }
 };
@@ -239,6 +250,26 @@ createColumnProperties.filterDescriptors = {
         },
         set: function(value) {
             this.filterRenderer = value;
+        }
+    },
+    rightIcon: {
+        configurable: true,
+        enumerable: true,
+        get: function() {
+            var result;
+            if (this.filterable) {
+                result = this.value.length ? 'filter-on' : 'filter-off';
+            }
+            return result;
+        },
+        set: function(value) {
+            // replace self with a simple instance var
+            Object.defineProperty(this, 'rightIcon', {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                value: value
+            });
         }
     }
 };

--- a/src/cellRenderers/SimpleCell.js
+++ b/src/cellRenderers/SimpleCell.js
@@ -46,12 +46,6 @@ var SimpleCell = CellRenderer.extend('SimpleCell', {
                 centerIcon = val;
                 val = null;
             }
-        } else if (config.isFilterRow) {
-            if (config.isHandleColumn) {
-                leftIcon = images['filter-off'];
-            } else if (config.filterable) {
-                rightIcon = images[val.length ? 'filter-on' : 'filter-off'];
-            }
         } else {
             leftIcon = images[config.leftIcon];
             centerIcon = images[config.centerIcon];


### PR DESCRIPTION
Moves the filter icon logic to a getter on the properties object, similarly to Part 1 which moved the row handle icon code.

Both these enhancements merely make it easier to override that logic.