### PR TITLE
GRID-490: Partial render leaves selection frame fragments

### DIFF
--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -4,12 +4,14 @@ var defaults = require('../defaults');
 
 /**
  * @summary Dynamic property getter/setters.
- * @desc Dynamic properties can make use of a backing store.
+ * @desc ### Backing store
+ * Dynamic properties can make use of a backing store.
  * This backing store is created in the "own" layer by {@link Hypergrid#clearState|clearState}.
  * The members of the backing store have the same names as the dynamic properties that utilize them.
  * They are initialized by {@link Hypergrid#clearState|clearState} to the default values from {@link module:defaults|defaults} object members (also) of the same name.
  *
- * Note: Because this initialization picks up the values from {@link module:defaults|defaults} when {@link Hypergrid#clearState|clearState} is called, any changes the application developer may wish to make to {@link module:defaults|defaults} should be made _prior to_ any grid instantiations.
+ * ### Themes
+ * This layer is also where themes are applied.
  * @name dynamicProperties
  * @module
  */

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -721,6 +721,9 @@ var Renderer = Base.extend('Renderer', {
             selectionRegionOutlineColor: gridProps.selectionRegionOutlineColor
         };
         this.grid.cellRenderers.get('lastselection').paint(gc, config);
+        if (this.paintCells.key === 'by-cells') {
+            this.paintCells.reset = true; // fixes GRID-490
+        }
     },
 
     /**


### PR DESCRIPTION
Fix was simply to reset partial ('by-cells') grid renderer after any selection which forces it to use the fallback ('by-columns-and-rows') grid render for the next repaint.

Pushing without further approval because of time constraint. (We want to get it into alpha before Barc starts their day.)