### PR TITLE
Canvas.graphicsContextAliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /node_modules*
 /demo/build
 ~*.*x
-/v?.*
+/v*.*.*

--- a/src/cellRenderers/SimpleCell.js
+++ b/src/cellRenderers/SimpleCell.js
@@ -226,7 +226,7 @@ function renderMultiLineText(gc, config, val, leftPadding, rightPadding) {
     gc.cache.textBaseline = 'middle';
 
     for (var i = 0; i < lines.length; i++) {
-        gc.fillText(lines[i], x + halignOffset, y + valignOffset + (i * textHeight));
+        gc.simpleText(lines[i], x + halignOffset, y + valignOffset + (i * textHeight));
     }
 
     gc.cache.restore(); // discard clipping region
@@ -310,7 +310,7 @@ function renderSingleLineText(gc, config, val, leftPadding, rightPadding) {
 
         gc.cache.textAlign = 'left';
         gc.cache.textBaseline = 'middle';
-        gc.fillText(val, x, y);
+        gc.simpleText(val, x, y);
     }
 
     return minWidth;

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -826,8 +826,16 @@ function getCachedContext(canvasElement, type) {
 
     gc.conditionalsStack = [];
 
+    Object.getOwnPropertyNames(Canvas.graphicsContextAliases).forEach(function(alias) {
+        gc[alias] = gc[Canvas.graphicsContextAliases[alias]];
+    });
+
     return Object.assign(gc, require('./graphics'));
 }
+
+Canvas.graphicsContextAliases = {
+    simpleText: 'fillText'
+};
 
 
 module.exports = Canvas;


### PR DESCRIPTION
This lets app developer create and call synonyms for specific gc methods. Such methods may then be overridden (or not).