### PR TITLE
Grid-459: Unable to resize Column

### DIFF
--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -166,7 +166,7 @@ window.onload = function() {
 
     var gridOptions = {
             data: people1,
-            margin: { bottom: '17px' },
+            margin: { bottom: '17px', right: '17px'},
             schema: Hypergrid.lib.fields.getSchema(people1),
             plugins: plugins
         },

--- a/src/features/ColumnResizing.js
+++ b/src/features/ColumnResizing.js
@@ -80,7 +80,16 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
             if (event.mousePoint.x <= 3) {
                 var columnIndex = event.gridCell.x - 1;
                 this.dragColumn = grid.behavior.getActiveColumn(columnIndex);
-                this.dragStartWidth = grid.renderer.visibleColumns[columnIndex].width;
+                //this.dragStartWidth = grid.renderer.visibleColumns[columnIndex].width;
+                var visibleColIndex = -1;
+                var dragColumn = this.dragColumn;
+                grid.renderer.visibleColumns.forEach(function(vCol, vIndex){
+                    var col = vCol.column;
+                    if (col.index === dragColumn.index){
+                        visibleColIndex = vIndex;
+                    }
+                });
+                this.dragStartWidth = grid.renderer.visibleColumns[visibleColIndex].width;
             } else {
                 this.dragColumn = event.column;
                 this.dragStartWidth = event.bounds.width;


### PR DESCRIPTION
Also fixes an error in console that occurs when 

Scenario A
1) Load Hypergrid Demo.
2) Click on Dashboard and click "Set Data 1(5000 rows)". To get more columns on the grid.
3) Scroll Horizontally so move to few columns to the right.
4) Now click on "FilterCell" and press Enter. 
5) You can see exception in console saying "columnIndex" not found.

Scenario B
1) Load Hypergrid Demo.
2) Apply a filter so that there are no records on the grid.
3) Now go back to the filter cell and press enter. 
4) You can see exception in console saying "rowIndex" not found.