### PR TITLE
ISSUE-515: Cannot Scroll to last Column

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -1176,7 +1176,7 @@ var Hypergrid = Base.extend('Hypergrid', {
 
                 // target is to right of scrollable columns; positive delta scrolls right
                 // Note: The +1 forces right-most column to scroll left (just in case it was only partially in view)
-                (delta = c - dw.corner.x + 1) > 0
+                (delta = c - dw.origin.x + 1) > 0
             )
         ) {
             this.sbHScroller.index += delta;


### PR DESCRIPTION
@joneit I think this [issue](https://github.com/openfin/fin-hypergrid/issues/515) lies in how computeCellBounds builds the list of visibleColumns starting from the left where as the scrollH value diff is based on the right renderer.dataWindow.corner. The visibleColumns array maxes out based on available grid width before it even considering the column it was trying to show.