### PR TITLE
ISSUE#563: Standard Tree Column

### DIFF
--- a/add-ons/aggregations-view.js
+++ b/add-ons/aggregations-view.js
@@ -108,9 +108,6 @@ AggregationsView.prototype.setAggregateGroups = function(aggregations, groups) {
         dataSource.setAggregateGroups({}, []);
     }
 
-    behavior.createColumns(); // columns changed
-    behavior.changed(); // number of rows changed
-
     // 3. SAVE OR RESTORE SOME RENDER PROPERTIES
 
     if (aggregated) {
@@ -124,6 +121,8 @@ AggregationsView.prototype.setAggregateGroups = function(aggregations, groups) {
         // save value of grid's checkboxOnlyRowSelections property and set it to true so drill-down clicks don't select the row they are in
         this.checkboxOnlyRowSelectionsWas = state.checkboxOnlyRowSelections;
         state.checkboxOnlyRowSelections = true;
+        //Turn on Tree Column
+        grid.properties.showTreeColumn = true;
     } else {
         // restore the saved render props
         columnProps.editable = this.editableWas;
@@ -132,8 +131,12 @@ AggregationsView.prototype.setAggregateGroups = function(aggregations, groups) {
 
         // 3a. ON UNGROUPING: RESTORE PIPELINE
         behavior.unstashPipeline();
+        //Turn off Tree Column
+        grid.properties.showTreeColumn = false;
     }
 
+    behavior.createColumns(); // columns changed
+    behavior.changed(); // number of rows changed
     grid.selectionModel.clear();
     grid.clearMouseDown();
 

--- a/add-ons/tree-view.js
+++ b/add-ons/tree-view.js
@@ -48,6 +48,7 @@ function include(dataSource, defaultDataSource) {
 function TreeView(grid, options) {
     this.grid = grid;
     this.options = options || {};
+    grid.properties.showTreeColumn = false;
 }
 
 TreeView.prototype.name = 'TreeView';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "filter-tree": "0.4.0",
     "fin-hypergrid-data-source-base": "^0.4.10",
     "finbars": "1.5.2",
-    "hyper-analytics": "^0.13.0",
+    "hyper-analytics": "^0.15.0",
     "inject-stylesheet-template": "^1.0.1",
     "list-dragon": "1.3.3",
     "mustache": "2.2.0",

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -2010,7 +2010,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @memberOf Hypergrid#
      */
     isGridRow: function(y) {
-        return new this.beahvior.CellEvent(0, y).isDataRow;
+        return new this.behavior.CellEvent(0, y).isDataRow;
     },
 
     isShowHeaderRow: function() {
@@ -2033,7 +2033,7 @@ var Hypergrid = Base.extend('Hypergrid', {
         return this.behavior.hasHierarchyColumn();
     },
     isHierarchyColumn: function(x) {
-        return this.hasHierarchyColumn() && x === 0;
+        return this.hasHierarchyColumn() && x === this.behavior.treeColumnIndex;
     },
     checkScrollbarVisibility: function() {
         // var hoverClassOver = this.properties.scrollbarHoverOver;

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -131,7 +131,21 @@ var Behavior = Base.extend('Behavior', {
         return this.grid.renderer.visibleRows.length;
     },
 
+    get treeColumnIndex() {
+        return -1;
+    },
+
+    get rowColumnIndex() {
+        return -2;
+    },
+
+    get leftMostColIndex() {
+        return this.grid.properties.showRowNumbers ? this.rowColumnIndex : (this.hasHierarchyColumn() ? this.treeColumnIndex : 0);
+    },
+
     clearColumns: function() {
+        var tc = this.treeColumnIndex;
+        var rc = this.rowColumnIndex;
         /**
          * @type {Column[]}
          * @memberOf Behavior#
@@ -144,8 +158,16 @@ var Behavior = Base.extend('Behavior', {
          */
         this.allColumns = [];
 
-        this.allColumns[-1] = this.columns[-1] = this.newColumn({ index: -1 });
-        this.allColumns[-2] = this.columns[-2] = this.newColumn({ index: -2 });
+        this.allColumns[tc] = this.columns[tc] = this.newColumn({
+            index: tc,
+            header: this.dataModel.schema[tc].header,
+            calculator: this.dataModel.schema[tc].calculator
+        });
+        this.allColumns[rc] = this.columns[rc] = this.newColumn({
+            index: rc,
+            header: this.dataModel.schema[rc].header,
+            calculator: this.dataModel.schema[rc].calculator
+        });
 
         this.columnEnum = {};
     },
@@ -721,9 +743,11 @@ var Behavior = Base.extend('Behavior', {
      * @return {number} The width of the fixed column area in the hypergrid.
      */
     getFixedColumnsWidth: function() {
-        var count = this.getFixedColumnCount();
-        var total = 0;
-        for (var i = this.grid.properties.showRowNumbers ? -1 : 0; i < count; i++) {
+        var count = this.getFixedColumnCount(),
+            total = 0,
+            i = this.leftMostColIndex;
+
+        for (; i < count; i++) {
             total += this.getColumnWidth(i);
         }
         return total;
@@ -1260,7 +1284,7 @@ var Behavior = Base.extend('Behavior', {
     checkColumnAutosizing: function(force) {
         force = force === true;
         var autoSized = this.autoSizeRowNumberColumn() ||
-            this.hasHierarchyColumn() && this.allColumns[-2].checkColumnAutosizing(force);
+            this.hasHierarchyColumn() && this.allColumns[this.rowColumnIndex].checkColumnAutosizing(force);
         this.allColumns.forEach(function(column) {
             autoSized = column.checkColumnAutosizing(force) || autoSized;
         });
@@ -1269,7 +1293,7 @@ var Behavior = Base.extend('Behavior', {
 
     autoSizeRowNumberColumn: function() {
         if (this.grid.properties.showRowNumbers && this.grid.properties.rowNumberAutosizing) {
-            return this.allColumns[-1].checkColumnAutosizing(true);
+            return this.allColumns[this.rowColumnIndex].checkColumnAutosizing(true);
         }
     },
 

--- a/src/behaviors/Column.js
+++ b/src/behaviors/Column.js
@@ -26,7 +26,7 @@ var images = require('../../images/index');
  *    -2   | Tree (drill-down) column
  */
 function Column(behavior, indexOrOptions) {
-    var index, schema, options;
+    var index, schema, options, icon;
 
     this.behavior = behavior;
     this.dataModel = behavior.dataModel;
@@ -64,12 +64,15 @@ function Column(behavior, indexOrOptions) {
     this.properties = options;
 
     switch (index) {
-        case -1:
+        case this.behavior.treeColumnIndex:
             // Width of icon + 3-pixel spacer (checked and unchecked should be same width)
-            var icon = images[Object.create(this.properties.rowHeader, { isDataRow: { value: true } }).leftIcon];
+            icon = images[Object.create(this.properties.treeHeader, { isDataRow: { value: true } }).leftIcon];
             this.properties.minimumColumnWidth = icon ? icon.width + 3 : 0;
             break;
-        case -2:
+        case this.behavior.rowColumnIndex:
+            // Width of icon + 3-pixel spacer (checked and unchecked should be same width)
+            icon = images[Object.create(this.properties.rowHeader, { isDataRow: { value: true } }).leftIcon];
+            this.properties.minimumColumnWidth = icon ? icon.width + 3 : 0;
             // This case avoids the "out of range" error.
             break;
         default:

--- a/src/behaviors/cellProperties.js
+++ b/src/behaviors/cellProperties.js
@@ -146,8 +146,18 @@ function getCellPropertiesObject(rowIndex, dataModel) {
  */
 function newCellPropertiesObject(rowIndex, dataModel) {
     var rowData = (dataModel || this.dataModel).getRow(rowIndex),
-        metaData = rowData.__META = rowData.__META || {};
-    return (metaData[this.name] = Object.create(this._index >= 0 ? this.properties : this.properties.rowHeader));
+        metaData = rowData.__META = rowData.__META || {},
+        props;
+
+    if (this._index >= 0) {
+        props = this.properties;
+    } else if (this._index === this.behavior.treeColumnIndex) {
+        props = this.properties.treeHeader;
+    } else if (this._index === this.behavior.rowColumnIndex) {
+        props = this.properties.rowHeader;
+    }
+
+    return (metaData[this.name] = Object.create(props));
 }
 
 module.exports = cell;

--- a/src/behaviors/columnProperties.js
+++ b/src/behaviors/columnProperties.js
@@ -159,6 +159,16 @@ createColumnProperties.treeHeaderDescriptors = {
             this.rowHeaderForegroundSelectionColor = value;
         }
     },
+    renderer: {
+        configurable: true,
+        enumerable: true,
+        get: function() {
+            return this.treeRenderer;
+        },
+        set: function(value) {
+            this.treeRenderer = value;
+        }
+    },
     backgroundSelectionColor: {
         configurable: true,
         enumerable: true,

--- a/src/cellRenderers/TreeCell.js
+++ b/src/cellRenderers/TreeCell.js
@@ -9,7 +9,7 @@ var CellRenderer = require('./CellRenderer');
 var TreeCell = CellRenderer.extend('TreeCell', {
 
     /**
-     * @desc A simple implementation of a tree cell renderer for use mainly with the qtree.
+     * @desc A simple implementation of a tree cell renderer for use mainly with the tree column.
      * @implements paintFunction
      * @memberOf TreeCell.prototype
      */

--- a/src/dataModels/JSON.js
+++ b/src/dataModels/JSON.js
@@ -61,7 +61,9 @@ var JSON = DataModel.extend('dataModels.JSON', {
         options = options || {};
         this.source = new this.DataSourceOrigin(
             options.data,
-            options.schema
+            options.schema,
+            this.grid.behavior.treeColumnIndex,
+            this.grid.behavior.rowColumnIndex
         );
 
         this.setPipeline({
@@ -123,13 +125,6 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @memberOf dataModels.JSON.prototype
      */
     getValue: function(x, y) {
-        if (this.hasHierarchyColumn()) {
-            if (x === -2) {
-                x = 0;
-            }
-        } else if (this.isDrillDown()) {
-            x += 1;
-        }
         return this.dataSource.getValue(x, y);
     },
 
@@ -149,13 +144,6 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @param value
      */
     setValue: function(x, r, value) {
-        if (this.hasHierarchyColumn()) {
-            if (x === -2) {
-                x = 0;
-            }
-        } else if (this.isDrillDown()) {
-            x += 1;
-        }
         this.dataSource.setValue(x, r, value);
     },
 
@@ -175,8 +163,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @returns {number}
      */
     getColumnCount: function() {
-        var showTree = this.grid.properties.showTreeColumn === true;
-        var offset = (this.isDrillDown() && !showTree) ? -1 : 0;
+        var offset = this.hasHierarchyColumn() ? -1 : 0;
         return this.dataSource.getColumnCount() + offset;
     },
 
@@ -391,9 +378,12 @@ var JSON = DataModel.extend('dataModels.JSON', {
         return this.deprecated('truncatePipeline(newLength)', 'setPipeline()', '1.2.0', arguments, 'Build a local pipeline (array of data source constructors) and pass it to setPipeline.');
     },
 
-    isDrillDown: function(event) {
-        var colIndex = event && event.gridCell && event.gridCell.x;
-        return this.dataSource.isDrillDown(colIndex);
+    isDrillDown: function() {
+        return this.dataSource.isDrillDown();
+    },
+
+    isDrillDownCol: function(event) {
+        return this.dataSource.isDrillDownCol(event);
     },
 
     /**
@@ -465,8 +455,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
      * @returns {boolean}
      */
     hasHierarchyColumn: function() {
-        var showTree = this.grid.properties.showTreeColumn === true;
-        return this.isDrillDown() && showTree;
+        return this.isDrillDown() && this.grid.properties.showTreeColumn;
     },
 
     /**
@@ -513,7 +502,7 @@ var JSON = DataModel.extend('dataModels.JSON', {
     toggleRow: function(y, expand, event) {
         //TODO: fire a row toggle event
         var changed;
-        if (this.isDrillDown(event)) {
+        if (this.isDrillDownCol(event)) {
             changed = this.dataSource.click(y, expand);
             if (changed) {
                 this.reindex({rowClick: true});

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -730,6 +730,13 @@ var defaults = {
 
     /**
      * @default
+     * @type {string}
+     * @memberOf module:defaults
+     */
+    treeRenderer: 'SimpleCell',
+
+    /**
+     * @default
      * @type {boolean}
      * @memberOf module:defaults
      */

--- a/src/features/CellClick.js
+++ b/src/features/CellClick.js
@@ -25,7 +25,7 @@ var CellClick = Feature.extend('CellClick', {
      * @memberOf CellClick#
      */
     handleClick: function(grid, event) {
-        var consumed = event.isDataCell && (
+        var consumed = (event.isDataCell || event.isHierarchyColumn) && (
             this.openLink(grid, event) !== undefined ||
             grid.cellClicked(event)
         );

--- a/src/features/ColumnResizing.js
+++ b/src/features/ColumnResizing.js
@@ -42,7 +42,7 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
      * @param {Object} event - the event details
      */
     overAreaDivider: function(grid, event) {
-        var leftMostColumnIndex = grid.properties.showRowNumbers ? -1 : 0;
+        var leftMostColumnIndex = grid.behavior.leftMostColIndex;
         return event.gridCell.x !== leftMostColumnIndex && event.mousePoint.x <= 3 ||
             event.mousePoint.x >= event.bounds.width - 3;
     },
@@ -81,9 +81,9 @@ var ColumnResizing = Feature.extend('ColumnResizing', {
                 var columnIndex = event.gridCell.x - 1;
                 this.dragColumn = grid.behavior.getActiveColumn(columnIndex);
                 //this.dragStartWidth = grid.renderer.visibleColumns[columnIndex].width;
-                var visibleColIndex = -1;
+                var visibleColIndex = grid.behavior.rowColumnIndex;
                 var dragColumn = this.dragColumn;
-                grid.renderer.visibleColumns.forEach(function(vCol, vIndex){
+                grid.renderer.visibleColumns.forEachWithNeg(function(vCol, vIndex){
                     var col = vCol.column;
                     if (col.index === dragColumn.index){
                         visibleColIndex = vIndex;

--- a/src/lib/DataSourceOrigin.js
+++ b/src/lib/DataSourceOrigin.js
@@ -15,9 +15,11 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
     /**
      * Currently a synonym for {@link DataSourceOrigin#setData} (see).
      */
-    initialize: function(data, schema) {
+    initialize: function(data, schema, ti, ri) {
         delete this.dataSource; // added by DataSourceBase#initialize but we don't want here
-        this._schema = [];
+        this.treeColumnIndex = ti;
+        this.rowColumnIndex = ri;
+        this._schema = setInternalColSchema.call(this, []);
         this.setData(data, schema);
     },
 
@@ -53,7 +55,10 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
     },
 
     get schema() { return this._schema; },
-    set schema(schema) { this._schema = schema; },
+    set schema(schema) {
+        schema = setInternalColSchema.call(this, schema);
+        this._schema = schema;
+    },
 
     /**
      * @memberOf DataSourceOrigin#
@@ -77,7 +82,7 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
                 schema[i] = { name: fields[i] };
             }
         }
-
+        schema = setInternalColSchema.call(this, schema);
         /**
          * @summary The array of column schema objects.
          * @name schema
@@ -326,6 +331,16 @@ var DataSourceOrigin = DataSourceBase.extend('DataSourceOrigin',  {
         }, this);
     }
 });
+
+function setInternalColSchema(schema) {
+    if (!schema[this.treeColumnIndex]) {
+        schema[this.treeColumnIndex] = {name: 'Tree', header: 'Tree'}; //Tree Column
+    }
+    if (!schema[this.rowColumnIndex]) {
+        schema[this.rowColumnIndex] = {name: '', header: ''}; //Row Handle Column
+    }
+    return schema;
+}
 
 
 module.exports = DataSourceOrigin;

--- a/src/lib/cellEventFactory.js
+++ b/src/lib/cellEventFactory.js
@@ -201,10 +201,10 @@ factory.prototypeDescriptors = Object.defineProperties({}, {
     isColumnFixed: { get: function() { return this.isDataColumn && this.gridCell.x < this.grid.properties.fixedColumnCount; } },
     isCellFixed:   { get: function() { return this.isRowFixed && this.isColumnFixed; } },
 
-    isHandleColumn: { get: function() { return !this.isDataColumn; } },
+    isHandleColumn: { get: function() { return this.gridCell.x === this.grid.behavior.rowColumnIndex && this.grid.properties.showRowNumbers; } },
     isHandleCell:   { get: function() { return this.isHandleColumn && this.isDataRow; } },
 
-    isHierarchyColumn: { get: function() { return this.gridCell.x === 0 && this.grid.properties.showTreeColumn && this.dataModel.isDrillDown(this.dataCell.x); } },
+    isHierarchyColumn: { get: function() { return this.gridCell.x === this.grid.behavior.treeColumnIndex; } },
 
     isHeaderRow:    { get: function() { return this.visibleRow.subgrid.isHeader; } },
     isHeaderHandle: { get: function() { return this.isHeaderRow && this.isHandleColumn; } },

--- a/src/renderer/bundle-columns.js
+++ b/src/renderer/bundle-columns.js
@@ -2,22 +2,19 @@
 
 function bundleColumns(resetCellEvents) {
     var gridProps = this.grid.properties,
-        vc, visibleColumns = this.visibleColumns,
         vr, visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0,
-        r, R = visibleRows.length,
-        p, pool;
+        r, R = visibleRows.length, pool;
 
     if (resetCellEvents) {
         pool = this.cellEventPool;
-        for (p = 0, c = c0; c < C; c++) {
-            vc = visibleColumns[c];
+        var p = 0;
+        this.visibleColumns.forEachWithNeg(function(vc) {
             for (r = 0; r < R; r++, p++) {
                 vr = visibleRows[r];
                 // reset pool member to reflect coordinates of cell in newly shaped grid
                 pool[p].reset(vc, vr);
             }
-        }
+        });
     }
 
     var bundle,
@@ -25,8 +22,7 @@ function bundleColumns(resetCellEvents) {
         gridPrefillColor = gridProps.backgroundColor,
         backgroundColor;
 
-    for (c = c0; c < C; c++) {
-        vc = visibleColumns[c];
+    this.visibleColumns.forEachWithNeg(function(vc) {
         backgroundColor = vc.column.properties.backgroundColor;
         if (bundle && bundle.backgroundColor === backgroundColor) {
             bundle.right = vc.right;
@@ -40,7 +36,7 @@ function bundleColumns(resetCellEvents) {
             };
             columnBundles.push(bundle);
         }
-    }
+    });
 
     this.columnBundles = columnBundles;
 }

--- a/src/renderer/bundle-rows.js
+++ b/src/renderer/bundle-rows.js
@@ -2,9 +2,7 @@
 
 function bundleRows(resetCellEvents) {
     var gridProps = this.grid.properties,
-        vc, visibleColumns = this.visibleColumns,
         vr, visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0,
         r, R = visibleRows.length,
         p, pool;
 
@@ -12,11 +10,11 @@ function bundleRows(resetCellEvents) {
         pool = this.cellEventPool;
         for (p = 0, r = 0; r < R; r++) {
             vr = visibleRows[r];
-            for (c = c0; c < C; c++, p++) {
-                vc = visibleColumns[c];
+            this.visibleColumns.forEachWithNeg(function(vc) { // eslint-disable-line no-loop-func
+                p++;
                 // reset pool member to reflect coordinates of cell in newly shaped grid
                 pool[p].reset(vc, vr);
-            }
+            });
         }
     }
 

--- a/src/renderer/by-cells.js
+++ b/src/renderer/by-cells.js
@@ -32,19 +32,18 @@ var paintCellsByColumnsAndRows = require('./by-columns-and-rows');
  * @memberOf Renderer.prototype
  */
 function paintCellsAsNeeded(gc) {
-    var grid = this.grid,
-        gridProps = grid.properties,
-        cellEvent,
-        vc, visibleColumns = this.visibleColumns,
+    var cellEvent,
+        visibleColumns = this.visibleColumns,
         visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0, cLast = C - 1,
+        C = visibleColumns.length, cLast = C - 1,
         r, R = visibleRows.length,
-        p, pool = this.cellEventPool,
+        p = 0, pool = this.cellEventPool,
         preferredWidth,
         columnClip,
         // clipToGrid,
         // viewWidth = C ? visibleColumns[cLast].right : 0,
         viewHeight = R ? visibleRows[R - 1].bottom : 0;
+
 
     if (!C || !R) { return; }
 
@@ -57,7 +56,7 @@ function paintCellsAsNeeded(gc) {
     // gc.clipSave(clipToGrid, 0, 0, viewWidth, viewHeight);
 
     // For each column...
-    for (p = 0, c = c0; c < C; c++) {
+    this.visibleColumns.forEachWithNeg(function(vc, c) {
         cellEvent = pool[p]; // first cell in column c
         vc = cellEvent.visibleColumn;
 
@@ -79,7 +78,7 @@ function paintCellsAsNeeded(gc) {
         gc.clipRestore(columnClip);
 
         cellEvent.column.properties.preferredWidth = Math.round(preferredWidth);
-    }
+    }.bind(this));
 
     // gc.clipRestore(clipToGrid);
 }

--- a/src/renderer/by-columns-and-rows.js
+++ b/src/renderer/by-columns-and-rows.js
@@ -29,11 +29,12 @@ function paintCellsByColumnsAndRows(gc) {
         cellEvent,
         rowBundle, rowBundles,
         columnBundle, columnBundles,
-        vc, visibleColumns = this.visibleColumns,
+        visibleColumns = this.visibleColumns,
         visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0, cLast = C - 1,
+        c, C = visibleColumns.length,
+        cLast = C - 1,
         r, R = visibleRows.length,
-        p, pool = this.cellEventPool,
+        pool = this.cellEventPool,
         preferredWidth,
         columnClip,
         // clipToGrid,
@@ -76,7 +77,9 @@ function paintCellsByColumnsAndRows(gc) {
     // gc.clipSave(clipToGrid, 0, 0, viewWidth, viewHeight);
 
     // For each column...
-    for (p = 0, c = c0; c < C; c++) {
+    var p = 0;
+    this.visibleColumns.forEachWithNeg(function(vc, c) {
+
         cellEvent = pool[p];
         vc = cellEvent.visibleColumn;
 
@@ -106,7 +109,7 @@ function paintCellsByColumnsAndRows(gc) {
         gc.clipRestore(columnClip);
 
         cellEvent.column.properties.preferredWidth = Math.round(preferredWidth);
-    }
+    }.bind(this));
 
     // gc.clipRestore(clipToGrid);
 

--- a/src/renderer/by-columns-discrete.js
+++ b/src/renderer/by-columns-discrete.js
@@ -25,15 +25,13 @@ var bundleColumns = require('./bundle-columns');
  * @memberOf Renderer.prototype
  */
 function paintCellsByColumnsDiscrete(gc) {
-    var grid = this.grid,
-        gridProps = grid.properties,
-        prefillColor,
+    var prefillColor,
         cellEvent,
-        vc, visibleColumns = this.visibleColumns,
+        visibleColumns = this.visibleColumns,
         visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0, cLast = C - 1,
+        C = visibleColumns.length, cLast = C - 1,
         r, R = visibleRows.length,
-        p, pool = this.cellEventPool,
+        pool = this.cellEventPool,
         preferredWidth,
         columnClip,
         // clipToGrid,
@@ -53,7 +51,8 @@ function paintCellsByColumnsDiscrete(gc) {
     // gc.clipSave(clipToGrid, 0, 0, viewWidth, viewHeight);
 
     // For each column...
-    for (p = 0, c = c0; c < C; c++) {
+    var p = 0;
+    this.visibleColumns.forEachWithNeg(function(vc, c) {
         cellEvent = pool[p]; // first cell in column c
         vc = cellEvent.visibleColumn;
 
@@ -78,7 +77,7 @@ function paintCellsByColumnsDiscrete(gc) {
         gc.clipRestore(columnClip);
 
         cellEvent.column.properties.preferredWidth = Math.round(preferredWidth);
-    }
+    }.bind(this));
 
     // gc.clipRestore(clipToGrid);
 

--- a/src/renderer/by-columns.js
+++ b/src/renderer/by-columns.js
@@ -34,16 +34,17 @@ function paintCellsByColumns(gc) {
         prefillColor, gridPrefillColor = gridProps.backgroundColor,
         cellEvent,
         columnBundle, columnBundles,
-        vc, visibleColumns = this.visibleColumns,
+        visibleColumns = this.visibleColumns,
         visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0, cLast = C - 1,
+        c, C = visibleColumns.length, cLast = C - 1,
         r, R = visibleRows.length,
-        p, pool = this.cellEventPool,
+        pool = this.cellEventPool,
         preferredWidth,
         columnClip,
         // clipToGrid,
         viewWidth = C ? visibleColumns[cLast].right : 0,
         viewHeight = R ? visibleRows[R - 1].bottom : 0;
+
 
     gc.clearRect(0, 0, this.bounds.width, this.bounds.height);
 
@@ -71,7 +72,8 @@ function paintCellsByColumns(gc) {
     // gc.clipSave(clipToGrid, 0, 0, viewWidth, viewHeight);
 
     // For each column...
-    for (p = 0, c = c0; c < C; c++) {
+    var p = 0;
+    this.visibleColumns.forEachWithNeg(function(vc, c) {
         cellEvent = pool[p]; // first cell in column c
         vc = cellEvent.visibleColumn;
 
@@ -95,7 +97,7 @@ function paintCellsByColumns(gc) {
         gc.clipRestore(columnClip);
 
         cellEvent.column.properties.preferredWidth = Math.round(preferredWidth);
-    }
+    }.bind(this));
 
     // gc.clipRestore(clipToGrid);
 

--- a/src/renderer/by-rows.js
+++ b/src/renderer/by-rows.js
@@ -27,9 +27,9 @@ function paintCellsByRows(gc) {
         prefillColor, rowPrefillColors, gridPrefillColor = gridProps.backgroundColor,
         cellEvent,
         rowBundle, rowBundles = this.rowBundles,
-        vc, visibleColumns = this.visibleColumns,
+        visibleColumns = this.visibleColumns,
         vr, visibleRows = this.visibleRows,
-        c, C = visibleColumns.length, c0 = gridProps.showRowNumbers ? -1 : 0, cLast = C - 1,
+        c, C = visibleColumns.length, c0 = 0, cLast = C - 1,
         r, R = visibleRows.length,
         p, pool = this.cellEventPool,
         preferredWidth = Array(C - c0).fill(0),
@@ -74,7 +74,8 @@ function paintCellsByRows(gc) {
         }
 
         // For each column (of each row)...
-        for (c = c0; c < C; c++, p++) {
+        this.visibleColumns.forEachWithNeg(function(vc) {  // eslint-disable-line no-loop-func
+            p++;
             cellEvent = pool[p]; // next cell across the row (redundant for first cell in row)
             vc = cellEvent.visibleColumn;
 
@@ -89,16 +90,16 @@ function paintCellsByRows(gc) {
             }
 
             gc.clipRestore(columnClip);
-        }
+        }.bind(this));
     }
 
     // gc.clipRestore(clipToGrid);
 
     this.paintGridlines(gc);
 
-    for (c = c0; c < C; c++) {
-        visibleColumns[c].column.properties.preferredWidth = Math.round(preferredWidth[c]);
-    }
+    this.visibleColumns.forEachWithNeg(function(vc, c) {
+        vc.column.properties.preferredWidth = Math.round(preferredWidth[c]);
+    });
 }
 
 paintCellsByRows.key = 'by-rows';


### PR DESCRIPTION
@joneit 

Paired with https://github.com/openfin/hyper-analytics/pull/54

Resolves

https://github.com/openfin/fin-hypergrid/issues/535
https://github.com/openfin/fin-hypergrid/issues/501
https://github.com/openfin/fin-hypergrid/issues/488
https://github.com/openfin/fin-hypergrid/issues/483
https://github.com/openfin/fin-hypergrid/issues/563


## Standard Tree Column

Added Standard TreeColumn index -1, moving rowHandleColumn index to -2
Users can now build their own heirarchal view leveraging the treeColumn, and its open to customization as with other columns
Steps
`grid.properties.showTreeColumn = true`
Implement `grid.behavior.dataModel.isDrillDown()`
Implement `grid.behavior.dataModel.isDrillDownCol(y)`
Implement `grid.behavior.dataModel.isLeafNode(y)`
Overrid `grid.behavior.dataModel.toggleRow` // In the future it will emit an event akin to drillDownClicked leveraging `grid.behavior.dataModel.isDrillDownCol(y)`
Implement `grid.behavior.dataModel.getValue` and `setValue` for when y is `-1` the treeColumn


Non-Colliding `findWithNeg`and `forEachWithNeg` functions and `totalLength` property for `grid.renderer.visibleColumns` array
	Handles iteration with negative indices
	Regular array methods work as expected
	Considered ES5 Proxy but not supported in Chrome 40

Updated `dataModel.isDrillDown()` and `dataModel.hasHierarchyColumn()`
Added `dataModel.isDrillDownCol(y)` and `dataModel.isLeafNode(y)` 
Updated `dataModel.dataSource.schema` to be aware of the tree and rowHandle column
Note that `dataModel.getHeaders()` or `dataModel.getFields()` still only relay information relating to  dataCells

Also added read-only accessors on behavior
`behavior.treeColumnIndex`
`behavior.rowNumColumnIndex`
`behavior.leftMostColumnIndex`

Updated Group and Aggregations View (*TO BE REMOVED*) to use the Tree Column
TreeView (*TO BE REMOVED*) was updated to reflect the new TreeColumn but to since it was designed differently that Group and Aggregations, it still uses a dataColumn that acts as a treeColumn

## Group View Bugs Resolved
Column State Gets Reset when Group View is Enabled
Moved Tree Column from Data Portion of the grid
