### PR TITLE
ISSUE-309: Grid state, part 2

### DIFF
--- a/demo/js/demo/setState.js
+++ b/demo/js/demo/setState.js
@@ -185,12 +185,6 @@ module.exports = function(demo, grid) {
     //grid.addProperties(myThemes.three);
 
     grid.takeFocus();
-    //see myThemes.js file for how to create a theme
-    //grid.addProperties(myThemes.one);
-    //grid.addProperties(myThemes.two);
-    //grid.addProperties(myThemes.three);
-
-    grid.takeFocus();
 
     demo.resetDashboard();
 };

--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -2143,13 +2143,6 @@ var Hypergrid = Base.extend('Hypergrid', {
     }
 });
 
-var VAR = '.var.';
-function hasVar(descriptor) {
-    return (
-        descriptor.get && descriptor.get.toString().indexOf(VAR) >= 0 ||
-        descriptor.set && descriptor.set.toString().indexOf(VAR) >= 0
-    );
-}
 /**
  * Creates an instance variable backer for use by the getters and setters described in {@link dynamicPropertyDescriptors}.
  * @constructor
@@ -2157,11 +2150,20 @@ function hasVar(descriptor) {
  * @private
  */
 function Var() {
+    var BACKING_STORE = '.var.';
     Object.getOwnPropertyNames(dynamicPropertyDescriptors).forEach(function(name) {
-        if (hasVar(Object.getOwnPropertyDescriptor(dynamicPropertyDescriptors, name))) {
+        var descriptor = dynamicPropertyDescriptors[name];
+        if (
+            methodContains(descriptor.get, BACKING_STORE) ||
+            methodContains(descriptor.set, BACKING_STORE)
+        ) {
             this[name] = defaults[name];
         }
     }, this);
+}
+
+function methodContains(method, sarg) {
+    return method && method.toString().indexOf(sarg) !== -1;
 }
 
 function findOrCreateContainer(boundingRect) {

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -120,7 +120,7 @@ var Behavior = Base.extend('Behavior', {
          * @type {subgridSpec[]}
          * @memberOf Hypergrid#
          */
-        this.subgrids = options.subgrids || this.subgrids || this.defaultSubgridSpecs;
+        this.subgrids = options.subgrids || this.subgrids || this.grid.properties.subgrids;
     },
 
     get renderedColumnCount() {

--- a/src/behaviors/Behavior.js
+++ b/src/behaviors/Behavior.js
@@ -408,6 +408,17 @@ var Behavior = Base.extend('Behavior', {
         }
     },
 
+    setColumnOrderByName: function(columnNames) {
+        if (Array.isArray(columnNames)){
+            this.columns.length = columnNames.length;
+            columnNames.forEach(function(columnName, i) {
+                this.columns[i] = this.allColumns.find(function(column) {
+                    return column.name === columnName;
+                });
+            }, this);
+        }
+    },
+
     _setColumnOrder: function(columnIndexes) {
         this.deprecated('_setColumnOrder(columnIndexes)', 'setColumnOrder(columnIndexes)', '1.2.10', arguments);
     },

--- a/src/behaviors/subgrids.js
+++ b/src/behaviors/subgrids.js
@@ -21,15 +21,6 @@ var dataModels = require('../dataModels');
  */
 
 module.exports = {
-    dataModels: {
-        HeaderSubgrid: dataModels.HeaderSubgrid
-    },
-
-    defaultSubgridSpecs: [
-        'HeaderSubgrid',
-        'data'
-    ],
-
     /**
      * An array where each element represents a subgrid to be rendered in the hypergrid.
      *
@@ -137,7 +128,7 @@ function derefSubgridRef(ref) {
     var Constructor;
     switch (typeof ref) {
         case 'string':
-            Constructor = this.dataModels[ref];
+            Constructor = dataModels[ref];
             break;
         case 'function':
             Constructor = ref;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -31,6 +31,17 @@ var defaults = {
      */
     noDataMessage: '',
 
+    /**
+     * @summary List of subgrids by
+     * @desc Restrict usage here to strings (naming data models) or arrays consisting of such a string + constructor arguments. That is, avoid {@link subgridSpec}'s function and object overloads and {@link subgridConstructorRef} function overload.
+     * @default "[ 'HeaderSubgrid', 'data' ]"
+     * @type {subgridSpec[]}
+     * @memberOf module:defaults
+     */
+    subgrids: [
+        'HeaderSubgrid',
+        'data'
+    ],
 
     /**
      * The font for data cells.

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -21,6 +21,18 @@ var dynamicPropertyDescriptors = {
     /**
      * @memberOf module:dynamicPropertyDescriptors
      */
+    subgrids: {
+        get: function() {
+            return this.var.subgrids;
+        },
+        set: function(subgrids) {
+            this.grid.behavior.subgrids = this.var.subgrids = subgrids;
+        }
+    },
+
+    /**
+     * @memberOf module:dynamicPropertyDescriptors
+     */
     gridRenderer: {
         get: function() {
             return this.var.gridRenderer;

--- a/src/lib/dynamicProperties.js
+++ b/src/lib/dynamicProperties.js
@@ -36,13 +36,30 @@ var dynamicPropertyDescriptors = {
      */
     columnIndexes: {
         get: function() {
-            return this.grid.behavior.getActiveColumns().map(function(column) { return column.index; });
+            return this.grid.behavior.getActiveColumns().map(function(column) {
+                return column.index;
+            });
         },
         set: function(columnIndexes) {
             this.grid.behavior.setColumnOrder(columnIndexes);
             this.grid.behavior.changed();
         }
     },
+
+    /**
+     * @memberOf module:dynamicPropertyDescriptors
+     */
+    columnNames: {
+        get: function() {
+            return this.grid.behavior.getActiveColumns().map(function(column) {
+                return column.name;
+            });
+        },
+        set: function(columnNames) {
+            this.grid.behavior.setColumnOrderByName(columnNames);
+            this.grid.behavior.changed();
+        }
+    }
 };
 
 module.exports = dynamicPropertyDescriptors;


### PR DESCRIPTION
See issue https://github.com/openfin/fin-hypergrid/issues/309 for details.

Task list:
- [x] `rows` _(merged in part 1)_
- [x] `columns` _(merged in part 1)_
- [x] `cells` _(merged in part 1)_
- [x] `columnNames`
- [x] `subgrids`
- [ ] `calculators`
- [ ] `plugins`
- [ ] accept a state object on grid instantiation (or allow the current `options` object to be a state object)
