### PR TITLE
Update scroll limits when adding new properties to the grid (defaultRowHeight may have changed)

### DIFF
--- a/src/Hypergrid.js
+++ b/src/Hypergrid.js
@@ -595,6 +595,7 @@ var Hypergrid = Base.extend('Hypergrid', {
      * @param {object} properties - An object of various key value pairs.
      */
     refreshProperties: function() {
+        this.synchronizeScrollingBoundaries();
         this.computeCellsBounds();
         this.checkScrollbarVisibility();
         this.behavior.defaultRowHeight = null;


### PR DESCRIPTION
Without this, when instantiating a new grid and then adding theming properties with addProperties(),
the scroll limits are not updated and only a portion of the grid may be accessible on scroll.